### PR TITLE
refactor: standardize in-app naming

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,17 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "🧱 Android: Assemble Example (Horizon/Auto)",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "bash",
+            "runtimeArgs": [
+                "-lc",
+                "./gradlew :Example:assembleDebug -PEXAMPLE_OPENIAP_STORE=auto"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "▶️ Android: Start Example Activity",
             "type": "node",
             "request": "launch",
@@ -66,6 +77,25 @@
                 "./gradlew :openiap:test --no-daemon"
             ],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "🎯 Android: Run Example (Horizon Force)",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "bash",
+            "runtimeArgs": [
+                "-lc",
+                "./gradlew :Example:installDebug -PEXAMPLE_OPENIAP_STORE=horizon -PEXAMPLE_HORIZON_APP_ID='${input:horizonAppId}' && adb shell am start -n dev.hyo.martie/.MainActivity"
+            ],
+            "console": "integratedTerminal"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "horizonAppId",
+            "type": "promptString",
+            "description": "Enter Horizon APP_ID",
+            "default": ""
         }
     ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,20 @@ cd openiap-google
 adb shell am start -n dev.hyo.martie/.MainActivity
 ```
 
+### Horizon Quickstart (Local)
+
+The core library ships Play-only by default but supports Horizon if a provider is on the classpath.
+
+- Provider selection is done via `OpenIapStore(context, store?, appId?)` or BuildConfig flags.
+- Run Example targeting Horizon/auto:
+  - VS Code: use launch config "Android: Run Example (Horizon/Auto)"
+  - CLI: `./gradlew :Example:installDebug -PEXAMPLE_OPENIAP_STORE=auto`
+  - CLI (force): `./gradlew :Example:installDebug -PEXAMPLE_OPENIAP_STORE=horizon -PEXAMPLE_HORIZON_APP_ID=YOUR_APP_ID`
+  - VS Code (force): use launch config "Android: Run Example (Horizon Force)" — it will prompt for `HORIZON_APP_ID` via input box and pass `-PEXAMPLE_HORIZON_APP_ID` to Gradle.
+- Notes:
+  - Use a Quest device with Meta services; emulators are not supported.
+  - If the provider is missing, the factory falls back to Play when using `auto`.
+
 ## Code Style
 
 - Follow the official Kotlin Coding Conventions

--- a/Example/build.gradle.kts
+++ b/Example/build.gradle.kts
@@ -17,6 +17,17 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+
+        // Optional store override for example app: play | horizon | auto
+        val store = (project.findProperty("EXAMPLE_OPENIAP_STORE") as String?) ?: "play"
+        buildConfigField("String", "OPENIAP_STORE", "\"${store}\"")
+
+        // Optional Horizon app id (provider-specific)
+        // Prefer EXAMPLE_HORIZON_APP_ID; fallback to legacy EXAMPLE_OPENIAP_APP_ID if provided
+        val appId = (project.findProperty("EXAMPLE_HORIZON_APP_ID") as String?)
+            ?: (project.findProperty("EXAMPLE_OPENIAP_APP_ID") as String?)
+            ?: ""
+        buildConfigField("String", "HORIZON_APP_ID", "\"${appId}\"")
     }
 
     buildTypes {
@@ -44,6 +55,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     packaging {

--- a/Example/src/main/java/dev/hyo/martie/Constants.kt
+++ b/Example/src/main/java/dev/hyo/martie/Constants.kt
@@ -1,14 +1,27 @@
 package dev.hyo.martie
 
 object IapConstants {
-    // App-defined SKU lists
-    val INAPP_SKUS = listOf(
+    private fun isHorizon(): Boolean =
+        dev.hyo.martie.BuildConfig.OPENIAP_STORE.equals("horizon", ignoreCase = true)
+
+    // Define your Horizon product IDs here (placeholders)
+    private val HORIZON_INAPP = listOf(
         "dev.hyo.martie.10bulbs",
-        "dev.hyo.martie.30bulbs"
+        "dev.hyo.martie.30bulbs",
+    )
+    private val HORIZON_SUBS = listOf(
+        "dev.hyo.martie.premium",
     )
 
-    val SUBS_SKUS = listOf(
-        "dev.hyo.martie.premium"
+    // Google Play product IDs (existing)
+    private val PLAY_INAPP = listOf(
+        "dev.hyo.martie.10bulbs",
+        "dev.hyo.martie.30bulbs",
     )
+    private val PLAY_SUBS = listOf(
+        "dev.hyo.martie.premium",
+    )
+
+    fun inappSkus(): List<String> = if (isHorizon()) HORIZON_INAPP else PLAY_INAPP
+    fun subsSkus(): List<String> = if (isHorizon()) HORIZON_SUBS else PLAY_SUBS
 }
-

--- a/Example/src/main/java/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
@@ -84,12 +84,12 @@ fun AvailablePurchasesScreen(
                                     val restored = iapStore.restorePurchases()
                                     iapStore.postStatusMessage(
                                         message = "Restored ${restored.size} purchases",
-                                        status = PurchaseResultStatus.SUCCESS
+                                        status = PurchaseResultStatus.Success
                                     )
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Restore failed",
-                                        status = PurchaseResultStatus.ERROR
+                                        status = PurchaseResultStatus.Error
                                     )
                                 }
                             }
@@ -202,7 +202,7 @@ fun AvailablePurchasesScreen(
             // Check for unfinished transactions (purchases that need acknowledgment/consumption)
             val unfinishedPurchases = purchases.filter { purchase ->
                 // TODO: In real implementation, check if purchase needs acknowledgment/consumption
-                // This would typically check: purchase.purchaseState == PURCHASED && !purchase.isAcknowledged
+                // This would typically check: purchase.purchaseState == PurchaseState.Purchased && !purchase.isAcknowledged
                 // For demo purposes, let's assume some consumable purchases might need finishing
                 (purchase.productId.contains("consumable", ignoreCase = true) ||
                  purchase.productId.contains("bulb", ignoreCase = true)) && 
@@ -225,21 +225,21 @@ fun AvailablePurchasesScreen(
                                     if (ok) {
                                         iapStore.postStatusMessage(
                                             message = "Transaction finished successfully",
-                                            status = PurchaseResultStatus.SUCCESS,
+                                            status = PurchaseResultStatus.Success,
                                             productId = purchase.productId
                                         )
                                         iapStore.getAvailablePurchases()
                                     } else {
                                         iapStore.postStatusMessage(
                                             message = "Failed to finish transaction",
-                                            status = PurchaseResultStatus.ERROR,
+                                            status = PurchaseResultStatus.Error,
                                             productId = purchase.productId
                                         )
                                     }
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Failed to finish transaction",
-                                        status = PurchaseResultStatus.ERROR,
+                                        status = PurchaseResultStatus.Error,
                                         productId = purchase.productId
                                     )
                                 }
@@ -311,7 +311,7 @@ fun AvailablePurchasesScreen(
                 items(nonConsumables) { purchase ->
                     PurchaseItemCard(
                         purchase = purchase,
-                        type = PurchaseType.NON_CONSUMABLE,
+                        type = PurchaseType.NonConsumable,
                         onClick = { selectedPurchase = purchase }
                     )
                 }
@@ -326,7 +326,7 @@ fun AvailablePurchasesScreen(
                 items(consumables) { purchase ->
                     PurchaseItemCard(
                         purchase = purchase,
-                        type = PurchaseType.CONSUMABLE,
+                        type = PurchaseType.Consumable,
                         onClick = { selectedPurchase = purchase }
                     )
                 }
@@ -419,12 +419,12 @@ fun AvailablePurchasesScreen(
                                     val restored = iapStore.restorePurchases()
                                     iapStore.postStatusMessage(
                                         message = "Restored ${restored.size} purchases",
-                                        status = PurchaseResultStatus.SUCCESS
+                                        status = PurchaseResultStatus.Success
                                     )
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Restore failed",
-                                        status = PurchaseResultStatus.ERROR
+                                        status = PurchaseResultStatus.Error
                                     )
                                 }
                             }
@@ -451,9 +451,9 @@ fun AvailablePurchasesScreen(
 }
 
 enum class PurchaseType {
-    CONSUMABLE,
-    NON_CONSUMABLE,
-    SUBSCRIPTION
+    Consumable,
+    NonConsumable,
+    Subscription,
 }
 
 @Composable
@@ -463,17 +463,17 @@ fun PurchaseItemCard(
     onClick: () -> Unit
 ) {
     val (backgroundColor, iconColor, icon) = when (type) {
-        PurchaseType.SUBSCRIPTION -> Triple(
+        PurchaseType.Subscription -> Triple(
             AppColors.secondary.copy(alpha = 0.1f),
             AppColors.secondary,
             Icons.Default.Autorenew
         )
-        PurchaseType.NON_CONSUMABLE -> Triple(
+        PurchaseType.NonConsumable -> Triple(
             AppColors.success.copy(alpha = 0.1f),
             AppColors.success,
             Icons.Default.CheckCircle
         )
-        PurchaseType.CONSUMABLE -> Triple(
+        PurchaseType.Consumable -> Triple(
             AppColors.warning.copy(alpha = 0.1f),
             AppColors.warning,
             Icons.Default.Schedule

--- a/Example/src/main/java/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
@@ -33,8 +33,15 @@ fun AvailablePurchasesScreen(
     storeParam: OpenIapStore? = null
 ) {
     val context = LocalContext.current
+    val appContext = context.applicationContext
     val iapStore = storeParam ?: (IapContext.LocalOpenIapStore.current
-        ?: IapContext.rememberOpenIapStore())
+        ?: remember(appContext) {
+            val storeKey = dev.hyo.martie.BuildConfig.OPENIAP_STORE
+            val appId = dev.hyo.martie.BuildConfig.HORIZON_APP_ID
+            android.util.Log.i("OpenIapFactory", "example-create storeKey=${storeKey} appIdSet=${appId.isNotEmpty()}")
+            runCatching { OpenIapStore(appContext, storeKey, appId) }
+                .getOrElse { OpenIapStore(appContext, "auto", appId) }
+        })
     val purchases by iapStore.availablePurchases.collectAsState()
     val status by iapStore.status.collectAsState()
     val connectionStatus by iapStore.connectionStatus.collectAsState()

--- a/Example/src/main/java/dev/hyo/martie/screens/OfferCodeScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/OfferCodeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -221,7 +222,7 @@ fun OfferCodeScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
-                            Icons.Default.HelpOutline,
+                            Icons.AutoMirrored.Filled.HelpOutline,
                             contentDescription = null,
                             tint = AppColors.primary
                         )

--- a/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -43,7 +43,16 @@ fun PurchaseFlowScreen(
     val activity = context as? Activity
     val uiScope = rememberCoroutineScope()
     val appContext = context.applicationContext as Context
-    val iapStore = storeParam ?: remember(appContext) { OpenIapStore(appContext) }
+    val iapStore = storeParam ?: remember(appContext) {
+        val storeKey = dev.hyo.martie.BuildConfig.OPENIAP_STORE
+        val appId = dev.hyo.martie.BuildConfig.HORIZON_APP_ID
+        android.util.Log.i("OpenIapFactory", "example-create storeKey=${storeKey} appIdSet=${appId.isNotEmpty()}")
+        runCatching { OpenIapStore(appContext, storeKey, appId) }
+            .getOrElse {
+                // Fallback to auto if horizon provider not present
+                OpenIapStore(appContext, "auto", appId)
+            }
+    }
     val products by iapStore.products.collectAsState()
     val purchases by iapStore.availablePurchases.collectAsState()
     val status by iapStore.status.collectAsState()
@@ -64,7 +73,7 @@ fun PurchaseFlowScreen(
                 if (connected) {
                     iapStore.setActivity(activity)
                     iapStore.fetchProducts(
-                        skus = IapConstants.INAPP_SKUS,
+                        skus = IapConstants.inappSkus(),
                         type = ProductRequest.ProductRequestType.INAPP
                     )
                     iapStore.getAvailablePurchases()
@@ -97,7 +106,7 @@ fun PurchaseFlowScreen(
                                 try {
                                     iapStore.setActivity(activity)
                                     iapStore.fetchProducts(
-                                        skus = IapConstants.INAPP_SKUS,
+                                        skus = IapConstants.inappSkus(),
                                         type = ProductRequest.ProductRequestType.INAPP
                                     )
                                 } catch (_: Exception) { }
@@ -311,7 +320,7 @@ fun PurchaseFlowScreen(
                             scope.launch {
                                 try {
                                     iapStore.fetchProducts(
-                                        skus = IapConstants.INAPP_SKUS,
+                                        skus = IapConstants.inappSkus(),
                                         type = ProductRequest.ProductRequestType.INAPP
                                     )
                                 } catch (_: Exception) { }

--- a/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -74,7 +74,7 @@ fun PurchaseFlowScreen(
                     iapStore.setActivity(activity)
                     iapStore.fetchProducts(
                         skus = IapConstants.inappSkus(),
-                        type = ProductRequest.ProductRequestType.INAPP
+                        type = ProductRequest.ProductRequestType.InApp
                     )
                     iapStore.getAvailablePurchases()
                 }
@@ -107,7 +107,7 @@ fun PurchaseFlowScreen(
                                     iapStore.setActivity(activity)
                                     iapStore.fetchProducts(
                                         skus = IapConstants.inappSkus(),
-                                        type = ProductRequest.ProductRequestType.INAPP
+                                        type = ProductRequest.ProductRequestType.InApp
                                     )
                                 } catch (_: Exception) { }
                             }
@@ -196,7 +196,7 @@ fun PurchaseFlowScreen(
                             status = result.status,
                             onDismiss = { iapStore.clearStatusMessage() }
                         )
-                        if (result.status == PurchaseResultStatus.SUCCESS) {
+                        if (result.status == PurchaseResultStatus.Success) {
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -235,8 +235,8 @@ fun PurchaseFlowScreen(
                         isPurchasing = status.isPurchasing(product.id),
                         onPurchase = {
                             scope.launch {
-                                val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                                    ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                                val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                                    ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                                 iapStore.setActivity(activity)
                                 iapStore.requestPurchase(
                                     params = RequestPurchaseParams(skus = listOf(product.id)),
@@ -297,12 +297,12 @@ fun PurchaseFlowScreen(
                                     val restored = iapStore.restorePurchases()
                                     iapStore.postStatusMessage(
                                         message = "Restored ${restored.size} purchases",
-                                        status = PurchaseResultStatus.SUCCESS
+                                        status = PurchaseResultStatus.Success
                                     )
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Restore failed",
-                                        status = PurchaseResultStatus.ERROR
+                                        status = PurchaseResultStatus.Error
                                     )
                                 }
                             }
@@ -321,7 +321,7 @@ fun PurchaseFlowScreen(
                                 try {
                                     iapStore.fetchProducts(
                                         skus = IapConstants.inappSkus(),
-                                        type = ProductRequest.ProductRequestType.INAPP
+                                        type = ProductRequest.ProductRequestType.InApp
                                     )
                                 } catch (_: Exception) { }
                             }
@@ -355,7 +355,7 @@ fun PurchaseFlowScreen(
             if (!valid) {
                 iapStore.postStatusMessage(
                     message = "Receipt validation failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
                 return@LaunchedEffect
@@ -363,7 +363,7 @@ fun PurchaseFlowScreen(
             // 2) Determine consumable vs non-consumable
             val product = products.find { it.id == purchase.productId }
             val isConsumable = product?.let {
-                it.type == OpenIapProduct.ProductType.INAPP &&
+                it.type == OpenIapProduct.ProductType.InApp &&
                         (it.id.contains("consumable", true) || it.id.contains("bulb", true))
             } == true
 
@@ -381,14 +381,14 @@ fun PurchaseFlowScreen(
             if (!ok) {
                 iapStore.postStatusMessage(
                     message = "finishTransaction failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
             } else {
                 iapStore.loadPurchases()
                 iapStore.postStatusMessage(
                     message = "Purchase finished successfully",
-                    status = PurchaseResultStatus.SUCCESS,
+                    status = PurchaseResultStatus.Success,
                     productId = purchase.productId
                 )
                 selectedProduct = null
@@ -396,7 +396,7 @@ fun PurchaseFlowScreen(
         } catch (e: Exception) {
             iapStore.postStatusMessage(
                 message = e.message ?: "Failed to finish purchase",
-                status = PurchaseResultStatus.ERROR,
+                status = PurchaseResultStatus.Error,
                 productId = purchase.productId
             )
         }
@@ -409,8 +409,8 @@ fun PurchaseFlowScreen(
             onDismiss = { selectedProduct = null },
             onPurchase = {
                 uiScope.launch {
-                    val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                        ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                    val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                        ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                     iapStore.setActivity(activity)
                     iapStore.requestPurchase(
                         params = RequestPurchaseParams(skus = listOf(product.id)),

--- a/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -127,7 +127,7 @@ fun SubscriptionFlowScreen(
                     println("SubscriptionFlow: Loading subscription products: ${IapConstants.subsSkus()}")
                     iapStore.fetchProducts(
                         skus = IapConstants.subsSkus(),
-                        type = ProductRequest.ProductRequestType.SUBS
+                        type = ProductRequest.ProductRequestType.Subs
                     )
                     iapStore.getAvailablePurchases()
                 }
@@ -161,7 +161,7 @@ fun SubscriptionFlowScreen(
                                     iapStore.setActivity(activity)
                     iapStore.fetchProducts(
                         skus = IapConstants.subsSkus(),
-                        type = ProductRequest.ProductRequestType.SUBS
+                        type = ProductRequest.ProductRequestType.Subs
                     )
                                 } catch (_: Exception) { }
                             }
@@ -291,21 +291,21 @@ fun SubscriptionFlowScreen(
                     ProductCard(
                         product = product,
                         isPurchasing = status.isPurchasing(product.id),
-                        isSubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.PURCHASED },
+                        isSubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.Purchased },
                         onPurchase = {
                             // Prevent re-purchase if already subscribed
-                            val alreadySubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.PURCHASED }
+                            val alreadySubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.Purchased }
                             if (alreadySubscribed) {
                                 iapStore.postStatusMessage(
                                     message = "Already subscribed to ${product.id}",
-                                    status = PurchaseResultStatus.INFO,
+                                    status = PurchaseResultStatus.Info,
                                     productId = product.id
                                 )
                                 return@ProductCard
                             }
                             scope.launch {
-                                val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                                    ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                                val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                                    ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                                 iapStore.setActivity(activity)
                                 iapStore.requestPurchase(
                                     params = RequestPurchaseParams(skus = listOf(product.id)),
@@ -391,7 +391,7 @@ fun SubscriptionFlowScreen(
             if (!valid) {
                 iapStore.postStatusMessage(
                     message = "Receipt validation failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
                 return@LaunchedEffect
@@ -399,7 +399,7 @@ fun SubscriptionFlowScreen(
             // 2) Determine consumable vs non-consumable (subs -> false)
             val product = products.find { it.id == purchase.productId }
             val isConsumable = product?.let {
-                it.type == OpenIapProduct.ProductType.INAPP &&
+                it.type == OpenIapProduct.ProductType.InApp &&
                         (it.id.contains("consumable", true) || it.id.contains("bulb", true))
             } == true
 
@@ -417,7 +417,7 @@ fun SubscriptionFlowScreen(
             if (!ok) {
                 iapStore.postStatusMessage(
                     message = "finishTransaction failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
             } else {
@@ -426,7 +426,7 @@ fun SubscriptionFlowScreen(
         } catch (e: Exception) {
             iapStore.postStatusMessage(
                 message = e.message ?: "Failed to finish purchase",
-                status = PurchaseResultStatus.ERROR,
+                status = PurchaseResultStatus.Error,
                 productId = purchase.productId
             )
         }
@@ -439,8 +439,8 @@ fun SubscriptionFlowScreen(
             onDismiss = { selectedProduct = null },
             onPurchase = {
                 uiScope.launch {
-                    val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                        ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                    val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                        ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                     iapStore.setActivity(activity)
                     iapStore.requestPurchase(
                         params = RequestPurchaseParams(skus = listOf(product.id)),

--- a/Example/src/main/java/dev/hyo/martie/screens/uis/Modals.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/uis/Modals.kt
@@ -77,7 +77,7 @@ fun ProductDetailModal(
                     }
                 }
                 
-                Divider()
+                HorizontalDivider()
                 
                 // Product Info
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -126,7 +126,7 @@ fun ProductDetailModal(
                         Surface(
                             shape = RoundedCornerShape(8.dp),
                             color = when (product.type) {
-                                OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                                OpenIapProduct.ProductType.Subs -> AppColors.secondary
                                 else -> AppColors.primary
                             }.copy(alpha = 0.2f)
                         ) {
@@ -136,7 +136,7 @@ fun ProductDetailModal(
                                 style = MaterialTheme.typography.labelMedium,
                                 fontWeight = FontWeight.SemiBold,
                                 color = when (product.type) {
-                                    OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                                    OpenIapProduct.ProductType.Subs -> AppColors.secondary
                                     else -> AppColors.primary
                                 }
                             )
@@ -173,7 +173,7 @@ fun ProductDetailModal(
                         }
                         
                         product.oneTimePurchaseOfferDetailsAndroid?.let { offer ->
-                            Divider(modifier = Modifier.padding(vertical = 4.dp))
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                             Text(
                                 "One-Time Purchase Details",
                                 style = MaterialTheme.typography.labelLarge,
@@ -185,7 +185,7 @@ fun ProductDetailModal(
                         
                         product.subscriptionOfferDetailsAndroid?.let { offers ->
                             if (offers.isNotEmpty()) {
-                                Divider(modifier = Modifier.padding(vertical = 4.dp))
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                                 Text(
                                     "Subscription Offers",
                                     style = MaterialTheme.typography.labelLarge,
@@ -312,7 +312,7 @@ fun PurchaseDetailModal(
                     }
                 }
                 
-                Divider()
+                HorizontalDivider()
                 
                 // Purchase Status
                 Row(
@@ -322,16 +322,16 @@ fun PurchaseDetailModal(
                 ) {
                     Icon(
                         when (purchase.purchaseState) {
-                            OpenIapPurchase.PurchaseState.PURCHASED -> Icons.Default.CheckCircle
-                            OpenIapPurchase.PurchaseState.PENDING -> Icons.Default.Schedule
-                            OpenIapPurchase.PurchaseState.FAILED -> Icons.Default.Error
+                            OpenIapPurchase.PurchaseState.Purchased -> Icons.Default.CheckCircle
+                            OpenIapPurchase.PurchaseState.Pending -> Icons.Default.Schedule
+                            OpenIapPurchase.PurchaseState.Failed -> Icons.Default.Error
                             else -> Icons.Default.Info
                         },
                         contentDescription = null,
                         tint = when (purchase.purchaseState) {
-                            OpenIapPurchase.PurchaseState.PURCHASED -> AppColors.success
-                            OpenIapPurchase.PurchaseState.PENDING -> AppColors.warning
-                            OpenIapPurchase.PurchaseState.FAILED -> AppColors.danger
+                            OpenIapPurchase.PurchaseState.Purchased -> AppColors.success
+                            OpenIapPurchase.PurchaseState.Pending -> AppColors.warning
+                            OpenIapPurchase.PurchaseState.Failed -> AppColors.danger
                             else -> AppColors.info
                         },
                         modifier = Modifier.size(32.dp)
@@ -405,7 +405,7 @@ fun PurchaseDetailModal(
                     }
                     
                     // Android specific details
-                    Divider(modifier = Modifier.padding(vertical = 4.dp))
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                     Text(
                         "Android Details",
                         style = MaterialTheme.typography.labelLarge,
@@ -430,7 +430,7 @@ fun PurchaseDetailModal(
                     
                     // Token info
                     if (!purchase.purchaseToken.isNullOrEmpty()) {
-                        Divider(modifier = Modifier.padding(vertical = 4.dp))
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                         Text(
                             "Token Information",
                             style = MaterialTheme.typography.labelLarge,

--- a/Example/src/main/java/dev/hyo/martie/screens/uis/ProductCard.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/uis/ProductCard.kt
@@ -65,7 +65,7 @@ fun ProductCard(
                     Surface(
                         shape = RoundedCornerShape(4.dp),
                         color = when (product.type) {
-                            OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                            OpenIapProduct.ProductType.Subs -> AppColors.secondary
                             else -> AppColors.primary
                         }.copy(alpha = 0.2f)
                     ) {
@@ -74,7 +74,7 @@ fun ProductCard(
                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                             style = MaterialTheme.typography.labelSmall,
                             color = when (product.type) {
-                                OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                                OpenIapProduct.ProductType.Subs -> AppColors.secondary
                                 else -> AppColors.primary
                             }
                         )

--- a/Example/src/main/java/dev/hyo/martie/screens/uis/PurchaseResultCard.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/uis/PurchaseResultCard.kt
@@ -21,9 +21,9 @@ fun PurchaseResultCard(
     onDismiss: () -> Unit
 ) {
     val (background, contentColor, icon) = when (status) {
-        PurchaseResultStatus.SUCCESS -> Triple(AppColors.success.copy(alpha = 0.1f), AppColors.success, Icons.Default.CheckCircle)
-        PurchaseResultStatus.INFO -> Triple(AppColors.info.copy(alpha = 0.1f), AppColors.info, Icons.Default.Info)
-        PurchaseResultStatus.ERROR -> Triple(AppColors.danger.copy(alpha = 0.1f), AppColors.danger, Icons.Default.ErrorOutline)
+        PurchaseResultStatus.Success -> Triple(AppColors.success.copy(alpha = 0.1f), AppColors.success, Icons.Default.CheckCircle)
+        PurchaseResultStatus.Info -> Triple(AppColors.info.copy(alpha = 0.1f), AppColors.info, Icons.Default.Info)
+        PurchaseResultStatus.Error -> Triple(AppColors.danger.copy(alpha = 0.1f), AppColors.danger, Icons.Default.ErrorOutline)
     }
     Card(
         modifier = Modifier

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun handlePurchaseUpdate(purchase: OpenIapPurchase) {
         when (purchase.purchaseState) {
-            PurchaseState.PURCHASED -> {
+            PurchaseState.Purchased -> {
                 // Acknowledge or consume the purchase
                 lifecycleScope.launch {
                     try {
@@ -212,7 +212,7 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
             }
-            PurchaseState.PENDING -> {
+            PurchaseState.Pending -> {
                 // Purchase is pending (e.g., awaiting payment)
             }
             // Handle other states...
@@ -267,6 +267,8 @@ suspend fun getAvailableItemsByType(type: String): List<OpenIapPurchase>
 suspend fun acknowledgePurchase(purchaseToken: String): Boolean
 suspend fun consumePurchase(purchaseToken: String): Boolean
 ```
+
+> Note: Use `"in-app"` for in-app product types. The legacy alias `"inapp"` remains available for compatibility but will be removed in version 1.2.0.
 
 #### Store Information
 

--- a/openiap/build.gradle.kts
+++ b/openiap/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
+// Keep minimal: single-variant by default; BuildConfig flag added below
+
 // Resolve version from either 'openIapVersion' or 'OPENIAP_VERSION' or fallback
 val openIapVersion: String =
     (project.findProperty("openIapVersion")
@@ -20,6 +22,10 @@ android {
         
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+        // Minimal provider selection (default: play)
+        buildConfigField("String", "OPENIAP_STORE", "\"play\"")
+        // Optional Horizon app id (provider-specific). Empty by default.
+        buildConfigField("String", "HORIZON_APP_ID", "\"\"")
     }
 
     buildTypes {
@@ -44,6 +50,7 @@ android {
     // Enable Compose for composables in this library (IapContext)
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -53,6 +60,11 @@ dependencies {
     
     // Google Play Billing Library (align with app/lib v8)
     api("com.android.billingclient:billing-ktx:8.0.0")
+
+    // Meta Horizon Billing Compatibility SDK (optional provider)
+    implementation("com.meta.horizon.billingclient.api:horizon-billing-compatibility:1.1.1")
+    // Meta Horizon Platform SDK (required alongside billing compat)
+    implementation("com.meta.horizon.platform.ovr:android-platform-sdk:72")
     
     // Kotlin Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapLog.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapLog.kt
@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicReference
  * OpenIAP logging utility (Android parity with Apple side).
  * - Toggleable via isEnabled
  * - Optional external handler integration
- * - Level-based routing (DEBUG/INFO/WARN/ERROR)
+ * - Level-based routing (Debug/Info/Warn/Error)
  */
 object OpenIapLog {
-    enum class Level { DEBUG, INFO, WARN, ERROR }
+    enum class Level { Debug, Info, Warn, Error }
 
     private val enabled = AtomicBoolean(false)
     private val defaultTagRef = AtomicReference("OpenIAP")
@@ -31,10 +31,10 @@ object OpenIapLog {
     fun defaultTag(): String = defaultTagRef.get()
 
     // Shorthand APIs (match Apple naming)
-    fun debug(message: String, tag: String = defaultTag()) = log(Level.DEBUG, message, null, tag)
-    fun info(message: String, tag: String = defaultTag()) = log(Level.INFO, message, null, tag)
-    fun warn(message: String, tag: String = defaultTag()) = log(Level.WARN, message, null, tag)
-    fun error(message: String, tr: Throwable? = null, tag: String = defaultTag()) = log(Level.ERROR, message, tr, tag)
+    fun debug(message: String, tag: String = defaultTag()) = log(Level.Debug, message, null, tag)
+    fun info(message: String, tag: String = defaultTag()) = log(Level.Info, message, null, tag)
+    fun warn(message: String, tag: String = defaultTag()) = log(Level.Warn, message, null, tag)
+    fun error(message: String, tr: Throwable? = null, tag: String = defaultTag()) = log(Level.Error, message, tr, tag)
 
     // Backwards-compat alias with Android Log-style letters
     fun d(message: String, tag: String = defaultTag()) = debug(message, tag)
@@ -50,10 +50,10 @@ object OpenIapLog {
             return
         }
         when (level) {
-            Level.DEBUG -> Log.d(tag, message)
-            Level.INFO -> Log.i(tag, message)
-            Level.WARN -> Log.w(tag, message)
-            Level.ERROR -> Log.e(tag, message, tr)
+            Level.Debug -> Log.d(tag, message)
+            Level.Info -> Log.i(tag, message)
+            Level.Warn -> Log.w(tag, message)
+            Level.Error -> Log.e(tag, message, tr)
         }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapModule.kt
@@ -101,15 +101,15 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
             val products = mutableListOf<OpenIapProduct>()
 
             // Fetch in-app products if requested
-            if (params.type == ProductRequest.ProductRequestType.INAPP ||
-                params.type == ProductRequest.ProductRequestType.ALL) {
+            if (params.type == ProductRequest.ProductRequestType.InApp ||
+                params.type == ProductRequest.ProductRequestType.All) {
                 val inappProducts = queryProducts(params.skus, BillingClient.ProductType.INAPP)
                 products.addAll(inappProducts)
             }
 
             // Fetch subscription products if requested
-            if (params.type == ProductRequest.ProductRequestType.SUBS ||
-                params.type == ProductRequest.ProductRequestType.ALL) {
+            if (params.type == ProductRequest.ProductRequestType.Subs ||
+                params.type == ProductRequest.ProductRequestType.All) {
                 val subsProducts = queryProducts(params.skus, BillingClient.ProductType.SUBS)
                 products.addAll(subsProducts)
             }
@@ -139,7 +139,7 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
             currentPurchaseCallback = { result ->
                 continuation.resume(result.getOrElse { emptyList() })
             }
-            val desiredType = if (type == ProductRequest.ProductRequestType.SUBS)
+            val desiredType = if (type == ProductRequest.ProductRequestType.Subs)
                 BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
 
             val client = billingClient
@@ -172,7 +172,7 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
                 for (pd in detailsList) {
                     val builder = BillingFlowParams.ProductDetailsParams.newBuilder()
                         .setProductDetails(pd)
-                    if (type == ProductRequest.ProductRequestType.SUBS) {
+                    if (type == ProductRequest.ProductRequestType.Subs) {
                         val offerToken = pd.subscriptionOfferDetails?.firstOrNull()?.offerToken
                         if (offerToken.isNullOrEmpty()) {
                             OpenIapLog.w("No subscription offer available for ${pd.productId}", TAG)
@@ -341,7 +341,7 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
 
     override suspend fun getAvailableItems(type: ProductRequest.ProductRequestType): List<OpenIapPurchase> =
         withContext(Dispatchers.IO) {
-            val productType = if (type == ProductRequest.ProductRequestType.SUBS) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
+            val productType = if (type == ProductRequest.ProductRequestType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
             queryPurchases(productType)
         }
     
@@ -613,8 +613,8 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
             title = productDetails.title,
             description = productDetails.description,
             type = if (productType == BillingClient.ProductType.SUBS)
-                OpenIapProduct.ProductType.SUBS
-            else OpenIapProduct.ProductType.INAPP,
+                OpenIapProduct.ProductType.Subs
+            else OpenIapProduct.ProductType.InApp,
             displayName = productDetails.name,
             displayPrice = displayPrice,
             currency = currency,

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapProtocol.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapProtocol.kt
@@ -66,7 +66,8 @@ interface OpenIapProtocol {
     ): Boolean
 
     /**
-     * Get available purchases filtered by type (inapp or subs).
+     * Get available purchases filtered by type (`"in-app"` or `"subs"`).
+     * Note: `"inapp"` remains available for compatibility but will be removed in 1.2.0.
      */
     suspend fun getAvailableItems(type: dev.hyo.openiap.models.ProductRequest.ProductRequestType): List<OpenIapPurchase>
 
@@ -77,12 +78,12 @@ interface OpenIapProtocol {
     /**
      * Request a purchase for products or subscriptions.
      * @param request Purchase request parameters
-     * @param type Product type ('inapp' | 'subs'), required for Android
+     * @param type Product type (`"in-app"` | `"subs"`). `"inapp"` is supported until 1.2.0 for backwards compatibility.
      * @return Purchase object if successful, null if cancelled
      */
     suspend fun requestPurchase(
         request: RequestPurchaseParams,
-        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.INAPP
+        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.InApp
     ): List<OpenIapPurchase>
     
     /**

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapViewModel.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapViewModel.kt
@@ -22,13 +22,13 @@ class OpenIapViewModel(app: Application) : AndroidViewModel(app) {
     fun initConnection() { viewModelScope.launch { runCatching { store.initConnection() } } }
     fun endConnection() { viewModelScope.launch { runCatching { store.endConnection() } } }
 
-    fun fetchProducts(skus: List<String>, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.ALL) {
+    fun fetchProducts(skus: List<String>, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.All) {
         viewModelScope.launch { runCatching { store.fetchProducts(skus, type) } }
     }
 
     fun restorePurchases() { viewModelScope.launch { runCatching { store.restorePurchases() } } }
 
-    fun requestPurchase(params: RequestPurchaseParams, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.INAPP) {
+    fun requestPurchase(params: RequestPurchaseParams, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.InApp) {
         viewModelScope.launch { runCatching { store.requestPurchase(params, type) } }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/horizon/OpenIapHorizonModule.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/horizon/OpenIapHorizonModule.kt
@@ -100,9 +100,9 @@ class OpenIapHorizonModule(
         }
 
         when (params.type) {
-            ProductRequest.ProductRequestType.ALL -> { query(BillingClient.ProductType.INAPP); query(BillingClient.ProductType.SUBS) }
-            ProductRequest.ProductRequestType.INAPP -> query(BillingClient.ProductType.INAPP)
-            ProductRequest.ProductRequestType.SUBS -> query(BillingClient.ProductType.SUBS)
+            ProductRequest.ProductRequestType.All -> { query(BillingClient.ProductType.INAPP); query(BillingClient.ProductType.SUBS) }
+            ProductRequest.ProductRequestType.InApp -> query(BillingClient.ProductType.INAPP)
+            ProductRequest.ProductRequestType.Subs -> query(BillingClient.ProductType.SUBS)
         }
         results
     }
@@ -157,7 +157,7 @@ class OpenIapHorizonModule(
     ): List<OpenIapPurchase> = withContext(Dispatchers.IO) {
         val client = billingClient ?: throw OpenIapError.NotPrepared
         val activity = currentActivity ?: throw OpenIapError.MissingCurrentActivity
-        val desiredType = if (type == ProductRequest.ProductRequestType.SUBS) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
+        val desiredType = if (type == ProductRequest.ProductRequestType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
         if (request.skus.isEmpty()) throw OpenIapError.EmptySkuList
 
         val products = request.skus.map { sku ->
@@ -293,7 +293,7 @@ class OpenIapHorizonModule(
             id = details.productId,
             title = details.title,
             description = details.description,
-            type = if (productType == BillingClient.ProductType.SUBS) OpenIapProduct.ProductType.SUBS else OpenIapProduct.ProductType.INAPP,
+            type = if (productType == BillingClient.ProductType.SUBS) OpenIapProduct.ProductType.Subs else OpenIapProduct.ProductType.InApp,
             displayName = details.name,
             displayPrice = displayPrice,
             currency = currency,
@@ -341,7 +341,7 @@ class OpenIapHorizonModule(
             purchaseToken = purchase.purchaseToken,
             platform = "android",
             quantity = purchase.quantity,
-            purchaseState = OpenIapPurchase.PurchaseState.PURCHASED,
+            purchaseState = OpenIapPurchase.PurchaseState.Purchased,
             isAutoRenewing = purchase.isAutoRenewing(),
             purchaseTokenAndroid = purchase.purchaseToken,
             dataAndroid = purchase.originalJson,

--- a/openiap/src/main/java/dev/hyo/openiap/horizon/OpenIapHorizonModule.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/horizon/OpenIapHorizonModule.kt
@@ -1,0 +1,352 @@
+package dev.hyo.openiap.horizon
+
+import android.app.Activity
+import android.content.Context
+import com.meta.horizon.billingclient.api.*
+import dev.hyo.openiap.OpenIapError
+import dev.hyo.openiap.OpenIapLog
+import dev.hyo.openiap.OpenIapProtocol
+import dev.hyo.openiap.listener.OpenIapPurchaseErrorListener
+import dev.hyo.openiap.listener.OpenIapPurchaseUpdateListener
+import dev.hyo.openiap.models.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+
+class OpenIapHorizonModule(
+    private val context: Context,
+    private val appId: String? = null,
+) : OpenIapProtocol, PurchasesUpdatedListener {
+
+    private val TAG = "OpenIapHorizon"
+    private var billingClient: BillingClient? = null
+    private var currentActivity: Activity? = null
+    private var currentPurchaseCallback: ((Result<List<OpenIapPurchase>>) -> Unit)? = null
+
+    private val purchaseUpdateListeners = mutableSetOf<OpenIapPurchaseUpdateListener>()
+    private val purchaseErrorListeners = mutableSetOf<OpenIapPurchaseErrorListener>()
+
+    fun setActivity(activity: Activity?) { currentActivity = activity }
+
+    override suspend fun initConnection(): Boolean = withContext(Dispatchers.IO) {
+        suspendCancellableCoroutine { cont ->
+            try {
+                val builder = BillingClient.newBuilder(context)
+                    .setListener(this@OpenIapHorizonModule)
+                    .enablePendingPurchases()
+                if (!appId.isNullOrEmpty()) builder.setAppId(appId)
+                billingClient = builder.build()
+                billingClient?.startConnection(object : BillingClientStateListener {
+                    override fun onBillingSetupFinished(billingResult: BillingResult) {
+                        if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                            OpenIapLog.i("Horizon billing connected", TAG)
+                            cont.resume(true)
+                        } else {
+                            OpenIapLog.w("Horizon setup failed: ${billingResult.debugMessage}", TAG)
+                            cont.resume(false)
+                        }
+                    }
+
+                    override fun onBillingServiceDisconnected() {
+                        OpenIapLog.i("Horizon service disconnected", TAG)
+                    }
+                })
+            } catch (t: Throwable) {
+                OpenIapLog.w("Horizon init error: ${t.message}", TAG)
+                cont.resume(false)
+            }
+        }
+    }
+
+    override suspend fun endConnection(): Boolean = withContext(Dispatchers.IO) {
+        try {
+            billingClient?.endConnection()
+            billingClient = null
+            true
+        } catch (t: Throwable) { false }
+    }
+
+    override suspend fun fetchProducts(params: ProductRequest): List<OpenIapProduct> = withContext(Dispatchers.IO) {
+        val client = billingClient ?: throw OpenIapError.NotPrepared
+        if (params.skus.isEmpty()) throw OpenIapError.EmptySkuList
+
+        val results = mutableListOf<OpenIapProduct>()
+
+        suspend fun query(type: String) {
+            val productList = params.skus.map { sku ->
+                QueryProductDetailsParams.Product.newBuilder()
+                    .setProductId(sku)
+                    .setProductType(type)
+                    .build()
+            }
+            val q = QueryProductDetailsParams.newBuilder().setProductList(productList).build()
+            val details: List<ProductDetails> = suspendCancellableCoroutine { cont ->
+                client.queryProductDetailsAsync(q) { br, pd ->
+                    if (br.responseCode != BillingClient.BillingResponseCode.OK) {
+                        cont.resume(emptyList())
+                        return@queryProductDetailsAsync
+                    }
+                    val list = pd ?: emptyList()
+                    cont.resume(list)
+                }
+            }
+            details.forEach { results.add(convertProduct(it, type)) }
+        }
+
+        when (params.type) {
+            ProductRequest.ProductRequestType.ALL -> { query(BillingClient.ProductType.INAPP); query(BillingClient.ProductType.SUBS) }
+            ProductRequest.ProductRequestType.INAPP -> query(BillingClient.ProductType.INAPP)
+            ProductRequest.ProductRequestType.SUBS -> query(BillingClient.ProductType.SUBS)
+        }
+        results
+    }
+
+    override suspend fun getAvailablePurchases(options: PurchaseOptions?): List<OpenIapPurchase> = withContext(Dispatchers.IO) {
+        val client = billingClient ?: throw OpenIapError.NotPrepared
+        val list = mutableListOf<OpenIapPurchase>()
+        suspend fun q(type: String) {
+            suspendCancellableCoroutine { cont ->
+                client.queryPurchasesAsync(
+                    QueryPurchasesParams.newBuilder().setProductType(type).build()
+                ) { br, purchases ->
+                    if (br.responseCode != BillingClient.BillingResponseCode.OK) {
+                        cont.resume(emptyList())
+                        return@queryPurchasesAsync
+                    }
+                    cont.resume(purchases ?: emptyList())
+                }
+            }.forEach { list.add(convertPurchase(it, type)) }
+        }
+        q(BillingClient.ProductType.INAPP)
+        q(BillingClient.ProductType.SUBS)
+        list
+    }
+
+    override suspend fun getActiveSubscriptions(subscriptionIds: List<String>?): List<OpenIapActiveSubscription> {
+        return getAvailablePurchases(null)
+            .filter { it.isAutoRenewing == true }
+            .filter { subscriptionIds.isNullOrEmpty() || subscriptionIds.contains(it.productId) }
+            .map {
+                OpenIapActiveSubscription(
+                    productId = it.productId,
+                    isActive = true,
+                    transactionId = it.id,
+                    purchaseToken = it.purchaseToken,
+                    transactionDate = it.transactionDate,
+                    platform = "android",
+                    autoRenewingAndroid = it.isAutoRenewing
+                )
+            }
+    }
+
+    override suspend fun hasActiveSubscriptions(subscriptionIds: List<String>?): Boolean =
+        getActiveSubscriptions(subscriptionIds).isNotEmpty()
+
+    override suspend fun getAvailableItems(type: ProductRequest.ProductRequestType): List<OpenIapPurchase> =
+        getAvailablePurchases(null).filter { it.productId.isNotEmpty() }
+
+    override suspend fun requestPurchase(
+        request: RequestPurchaseAndroidProps,
+        type: ProductRequest.ProductRequestType,
+    ): List<OpenIapPurchase> = withContext(Dispatchers.IO) {
+        val client = billingClient ?: throw OpenIapError.NotPrepared
+        val activity = currentActivity ?: throw OpenIapError.MissingCurrentActivity
+        val desiredType = if (type == ProductRequest.ProductRequestType.SUBS) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
+        if (request.skus.isEmpty()) throw OpenIapError.EmptySkuList
+
+        val products = request.skus.map { sku ->
+            QueryProductDetailsParams.Product.newBuilder().setProductId(sku).setProductType(desiredType).build()
+        }
+        val q = QueryProductDetailsParams.newBuilder().setProductList(products).build()
+
+        suspendCancellableCoroutine<List<OpenIapPurchase>> { cont ->
+            currentPurchaseCallback = { result ->
+                if (cont.isActive) cont.resume(result.getOrElse { emptyList() })
+            }
+            client.queryProductDetailsAsync(q) { br, pd ->
+                if (br.responseCode != BillingClient.BillingResponseCode.OK) {
+                    purchaseErrorListeners.forEach { runCatching { it.onPurchaseError(OpenIapError.QueryProduct(br.debugMessage ?: "Query failed")) } }
+                    if (cont.isActive) cont.resume(emptyList())
+                    return@queryProductDetailsAsync
+                }
+                val details = pd ?: emptyList()
+                if (details.isEmpty()) {
+                    purchaseErrorListeners.forEach { runCatching { it.onPurchaseError(OpenIapError.SkuNotFound(request.skus.firstOrNull() ?: "")) } }
+                    if (cont.isActive) cont.resume(emptyList())
+                    return@queryProductDetailsAsync
+                }
+                val paramsList = details.map { d ->
+                    val b = BillingFlowParams.ProductDetailsParams.newBuilder().setProductDetails(d)
+                    if (desiredType == BillingClient.ProductType.SUBS) {
+                        d.subscriptionOfferDetails?.firstOrNull()?.offerToken?.let { token -> b.setOfferToken(token) }
+                    }
+                    b.build()
+                }
+                val flow = BillingFlowParams.newBuilder()
+                    .setProductDetailsParamsList(paramsList)
+                    .setIsOfferPersonalized(request.isOfferPersonalized == true)
+                    .apply {
+                        request.obfuscatedAccountIdAndroid?.let { id -> setObfuscatedAccountId(id) }
+                        request.obfuscatedProfileIdAndroid?.let { id -> setObfuscatedProfileId(id) }
+                    }
+                    .build()
+                val r = client.launchBillingFlow(activity, flow)
+                if (r.responseCode != BillingClient.BillingResponseCode.OK) {
+                    purchaseErrorListeners.forEach { runCatching { it.onPurchaseError(OpenIapError.PurchaseFailed(r.debugMessage ?: "Billing flow failed")) } }
+                    if (cont.isActive) cont.resume(emptyList())
+                }
+                // Wait for onPurchasesUpdated to deliver
+            }
+        }
+    }
+
+    override suspend fun finishTransaction(params: FinishTransactionParams): PurchaseResult = withContext(Dispatchers.IO) {
+        val client = billingClient ?: throw OpenIapError.NotPrepared
+        val token = params.purchase.purchaseToken ?: params.purchase.purchaseTokenAndroid ?: ""
+        if (params.isConsumable) {
+            suspendCancellableCoroutine { cont ->
+                client.consumeAsync(ConsumeParams.newBuilder().setPurchaseToken(token).build()) { br, _ ->
+                    cont.resume(PurchaseResult(responseCode = br.responseCode, debugMessage = br.debugMessage, purchaseToken = token))
+                }
+            }
+        } else {
+            suspendCancellableCoroutine { cont ->
+                client.acknowledgePurchase(AcknowledgePurchaseParams.newBuilder().setPurchaseToken(token).build()) { br ->
+                    cont.resume(PurchaseResult(responseCode = br.responseCode, debugMessage = br.debugMessage, purchaseToken = token))
+                }
+            }
+        }
+    }
+
+    override suspend fun validateReceipt(options: ReceiptValidationProps): ReceiptValidationResultAndroid? = null
+
+    override suspend fun acknowledgePurchaseAndroid(purchaseToken: String) {}
+    override suspend fun consumePurchaseAndroid(purchaseToken: String) {}
+
+    override suspend fun deepLinkToSubscriptions(options: DeepLinkOptions) {}
+
+    override suspend fun getStorefront(): String {
+        val client = billingClient ?: return ""
+        return suspendCancellableCoroutine { cont ->
+            client.getBillingConfigAsync(GetBillingConfigParams.newBuilder().build(), object : BillingConfigResponseListener {
+                override fun onBillingConfigResponse(result: BillingResult, config: BillingConfig?) {
+                    if (result.responseCode == BillingClient.BillingResponseCode.OK) {
+                        cont.resume(config?.countryCode ?: "")
+                    } else {
+                        cont.resume("")
+                    }
+                }
+            })
+        }
+    }
+
+    override fun addPurchaseUpdateListener(listener: OpenIapPurchaseUpdateListener) { purchaseUpdateListeners.add(listener) }
+    override fun removePurchaseUpdateListener(listener: OpenIapPurchaseUpdateListener) { purchaseUpdateListeners.remove(listener) }
+    override fun addPurchaseErrorListener(listener: OpenIapPurchaseErrorListener) { purchaseErrorListeners.add(listener) }
+    override fun removePurchaseErrorListener(listener: OpenIapPurchaseErrorListener) { purchaseErrorListeners.remove(listener) }
+
+    override fun onPurchasesUpdated(billingResult: BillingResult, purchases: List<Purchase>?) {
+        OpenIapLog.d("onPurchasesUpdated code=${billingResult.responseCode} count=${purchases?.size ?: 0}", TAG)
+        if (billingResult.responseCode == BillingClient.BillingResponseCode.OK && purchases != null) {
+            val mapped = purchases.map { convertPurchase(it, BillingClient.ProductType.INAPP) }
+            mapped.forEach { p -> purchaseUpdateListeners.forEach { runCatching { it.onPurchaseUpdated(p) } } }
+            currentPurchaseCallback?.invoke(Result.success(mapped))
+            currentPurchaseCallback = null
+        } else {
+            val err = when (billingResult.responseCode) {
+                BillingClient.BillingResponseCode.USER_CANCELED -> OpenIapError.UserCancelled
+                BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED -> OpenIapError.ItemAlreadyOwned
+                BillingClient.BillingResponseCode.ITEM_NOT_OWNED -> OpenIapError.ItemNotOwned
+                else -> OpenIapError.PurchaseFailed(billingResult.debugMessage ?: "Horizon purchase failed")
+            }
+            purchaseErrorListeners.forEach { runCatching { it.onPurchaseError(err) } }
+            currentPurchaseCallback?.invoke(Result.success(emptyList()))
+            currentPurchaseCallback = null
+        }
+    }
+
+    private fun convertProduct(details: ProductDetails, productType: String): OpenIapProduct {
+        val oneTime = details.oneTimePurchaseOfferDetails
+        val subsPhase = details.subscriptionOfferDetails?.firstOrNull()?.pricingPhases?.pricingPhaseList?.firstOrNull()
+        val displayPrice = if (productType == BillingClient.ProductType.SUBS) {
+            subsPhase?.formattedPrice ?: ""
+        } else {
+            oneTime?.formattedPrice ?: ""
+        }
+        val currency = if (productType == BillingClient.ProductType.SUBS) {
+            subsPhase?.priceCurrencyCode ?: ""
+        } else {
+            oneTime?.priceCurrencyCode ?: ""
+        }
+        val priceMicros = if (productType == BillingClient.ProductType.SUBS) {
+            subsPhase?.priceAmountMicros ?: 0L
+        } else {
+            oneTime?.priceAmountMicros ?: 0L
+        }
+        return OpenIapProduct(
+            id = details.productId,
+            title = details.title,
+            description = details.description,
+            type = if (productType == BillingClient.ProductType.SUBS) OpenIapProduct.ProductType.SUBS else OpenIapProduct.ProductType.INAPP,
+            displayName = details.name,
+            displayPrice = displayPrice,
+            currency = currency,
+            price = priceMicros.toDouble() / 1_000_000.0,
+            platform = "android",
+            nameAndroid = details.name,
+            oneTimePurchaseOfferDetailsAndroid = oneTime?.let {
+                OneTimePurchaseOfferDetail(
+                    priceCurrencyCode = it.priceCurrencyCode,
+                    formattedPrice = it.formattedPrice,
+                    priceAmountMicros = it.priceAmountMicros.toString(),
+                )
+            },
+            subscriptionOfferDetailsAndroid = details.subscriptionOfferDetails?.map { offer ->
+                SubscriptionOfferDetail(
+                    basePlanId = offer.basePlanId,
+                    offerId = offer.offerId,
+                    offerToken = offer.offerToken,
+                    offerTags = offer.offerTags,
+                    pricingPhases = PricingPhases(
+                        pricingPhaseList = offer.pricingPhases.pricingPhaseList.map { phase ->
+                            PricingPhase(
+                                formattedPrice = phase.formattedPrice,
+                                priceCurrencyCode = phase.priceCurrencyCode,
+                                billingPeriod = phase.billingPeriod,
+                                billingCycleCount = phase.billingCycleCount,
+                                priceAmountMicros = phase.priceAmountMicros.toString(),
+                                recurrenceMode = phase.recurrenceMode,
+                            )
+                        }
+                    )
+                )
+            }
+        )
+    }
+
+    private fun convertPurchase(purchase: Purchase, productType: String): OpenIapPurchase {
+        return OpenIapPurchase(
+            id = purchase.purchaseToken,
+            productId = purchase.products.firstOrNull() ?: "",
+            ids = purchase.products,
+            transactionId = purchase.orderId,
+            transactionDate = purchase.purchaseTime,
+            transactionReceipt = purchase.originalJson ?: "",
+            purchaseToken = purchase.purchaseToken,
+            platform = "android",
+            quantity = purchase.quantity,
+            purchaseState = OpenIapPurchase.PurchaseState.PURCHASED,
+            isAutoRenewing = purchase.isAutoRenewing(),
+            purchaseTokenAndroid = purchase.purchaseToken,
+            dataAndroid = purchase.originalJson,
+            signatureAndroid = purchase.signature,
+            autoRenewingAndroid = purchase.isAutoRenewing(),
+            isAcknowledgedAndroid = purchase.isAcknowledged(),
+            packageNameAndroid = purchase.packageName,
+            developerPayloadAndroid = purchase.developerPayload,
+            obfuscatedAccountIdAndroid = null,
+            obfuscatedProfileIdAndroid = null,
+        )
+    }
+}

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapEvent.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapEvent.kt
@@ -4,8 +4,7 @@ package dev.hyo.openiap.models
  * OpenIAP event identifiers (parity with Apple-side enum)
  */
 enum class OpenIapEvent {
-    PURCHASE_UPDATED,
-    PURCHASE_ERROR,
-    PROMOTED_PRODUCT_IOS
+    PurchaseUpdated,
+    PurchaseError,
+    PromotedProductIos,
 }
-

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProduct.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProduct.kt
@@ -23,12 +23,12 @@ data class OpenIapProduct(
     val subscriptionOfferDetailsAndroid: List<SubscriptionOfferDetail>? = null
 ) {
     enum class ProductType(val value: String) {
-        INAPP("inapp"),
-        SUBS("subs");
+        InApp("in-app"),
+        Subs("subs");
         
         companion object {
             fun fromString(value: String): ProductType = 
-                values().find { it.value == value } ?: INAPP
+                values().find { it.value == value } ?: InApp
         }
     }
 

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProductRequest.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProductRequest.kt
@@ -5,16 +5,28 @@ package dev.hyo.openiap.models
  */
 data class OpenIapProductRequest(
     val skus: List<String>,
-    val type: ProductRequestType = ProductRequestType.INAPP
+    val type: ProductRequestType = ProductRequestType.InApp
 ) {
     enum class ProductRequestType(val value: String) {
-        INAPP("inapp"),
-        SUBS("subs"),
-        ALL("all");
+        InApp("in-app"),
+        Subs("subs"),
+        All("all");
 
         companion object {
-            fun fromString(value: String): ProductRequestType =
-                values().find { it.value == value } ?: INAPP
+            private val INAPP_ALIASES = setOf(
+                "in-app",
+                "inapp", // Legacy alias slated for removal in 1.2.0
+            )
+
+            fun fromString(value: String): ProductRequestType {
+                val normalized = value.lowercase()
+                return when {
+                    normalized in INAPP_ALIASES -> InApp
+                    normalized == Subs.value -> Subs
+                    normalized == All.value -> All
+                    else -> InApp
+                }
+            }
         }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapPurchase.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapPurchase.kt
@@ -30,22 +30,22 @@ data class OpenIapPurchase(
     val obfuscatedProfileIdAndroid: String? = null
 ) {
     enum class PurchaseState(val value: String) {
-        PENDING("pending"),
-        PURCHASED("purchased"),
-        FAILED("failed"),
-        RESTORED("restored"), // iOS only but keeping for compatibility
-        DEFERRED("deferred"), // iOS only but keeping for compatibility
-        UNKNOWN("unknown");
+        Pending("pending"),
+        Purchased("purchased"),
+        Failed("failed"),
+        Restored("restored"), // iOS only but keeping for compatibility
+        Deferred("deferred"), // iOS only but keeping for compatibility
+        Unknown("unknown");
         
         companion object {
             fun fromString(value: String): PurchaseState = 
-                values().find { it.value == value } ?: UNKNOWN
+                values().find { it.value == value } ?: Unknown
                 
             fun fromBillingClientState(state: Int): PurchaseState = when (state) {
-                0 -> UNKNOWN // UNSPECIFIED_STATE
-                1 -> PURCHASED
-                2 -> PENDING
-                else -> UNKNOWN
+                0 -> Unknown // UNSPECIFIED_STATE
+                1 -> Purchased
+                2 -> Pending
+                else -> Unknown
             }
         }
     }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapRequestTypes.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapRequestTypes.kt
@@ -52,16 +52,28 @@ data class PurchaseOptions(
  */
 data class ProductRequest(
     val skus: List<String>,
-    val type: ProductRequestType = ProductRequestType.INAPP
+    val type: ProductRequestType = ProductRequestType.InApp
 ) {
     enum class ProductRequestType(val value: String) {
-        INAPP("inapp"),
-        SUBS("subs"),
-        ALL("all");
+        InApp("in-app"),
+        Subs("subs"),
+        All("all");
 
         companion object {
-            fun fromString(value: String): ProductRequestType =
-                values().find { it.value == value } ?: INAPP
+            private val INAPP_ALIASES = setOf(
+                "in-app",
+                "inapp", // Legacy alias slated for removal in 1.2.0
+            )
+
+            fun fromString(value: String): ProductRequestType {
+                val normalized = value.lowercase()
+                return when {
+                    normalized in INAPP_ALIASES -> InApp
+                    normalized == Subs.value -> Subs
+                    normalized == All.value -> All
+                    else -> InApp
+                }
+            }
         }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapValidationTypes.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapValidationTypes.kt
@@ -15,7 +15,7 @@ data class ReceiptValidationResultAndroid(
     val gracePeriodEndDate: Long,
     val parentProductId: String,
     val productId: String,
-    val productType: String, // "inapp" or "subs"
+    val productType: String, // "in-app" or "subs" ("inapp" legacy support)
     val purchaseDate: Long,
     val quantity: Int,
     val receiptId: String,
@@ -39,4 +39,3 @@ data class ReceiptValidationProps(
         val isSub: Boolean = false
     )
 }
-

--- a/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -52,7 +52,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
         _currentPurchase.value = purchase
         setStatusMessage(
             message = "Purchase successful",
-            status = PurchaseResultStatus.SUCCESS,
+            status = PurchaseResultStatus.Success,
             productId = purchase.productId,
             transactionId = purchase.id
         )
@@ -64,7 +64,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
             val message = OpenIapError.defaultMessage(OpenIapError.UserCancelled.CODE)
             setStatusMessage(
                 message = message,
-                status = PurchaseResultStatus.INFO,
+                status = PurchaseResultStatus.Info,
                 productId = pendingRequestProductId
             )
             _status.value = _status.value.copy(lastError = null)
@@ -75,7 +75,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
         val message = error.message?.takeIf { it.isNotBlank() } ?: OpenIapError.defaultMessage(code)
         setStatusMessage(
             message = message,
-            status = PurchaseResultStatus.ERROR,
+            status = PurchaseResultStatus.Error,
             productId = pendingRequestProductId,
             code = code
         )
@@ -145,7 +145,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     suspend fun fetchProducts(
         skus: List<String>,
-        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.ALL
+        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.All
     ): List<OpenIapProduct> {
         setLoading { it.fetchProducts = true }
         return try {
@@ -189,7 +189,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     suspend fun requestPurchase(
         params: RequestPurchaseParams,
-        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.INAPP
+        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.InApp
     ): List<OpenIapPurchase> {
         val skuForStatus = params.skus.firstOrNull()
         if (skuForStatus != null) {
@@ -255,7 +255,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
 
     private fun setError(message: String?) {
         val msg = message ?: "Operation failed"
-        setStatusMessage(msg, PurchaseResultStatus.ERROR)
+        setStatusMessage(msg, PurchaseResultStatus.Error)
         _status.value = _status.value.copy(lastError = message?.let {
             ErrorData(code = "ERROR", message = it)
         })
@@ -286,7 +286,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     ) {
         setStatusMessage(message, status, productId)
         _status.value = _status.value.copy(
-            lastError = if (status == PurchaseResultStatus.ERROR) {
+            lastError = if (status == PurchaseResultStatus.Error) {
                 ErrorData(code = "ERROR", message = message)
             } else {
                 null
@@ -361,12 +361,12 @@ data class PurchaseResultData(
     val productId: String?,
     val transactionId: String?,
     val message: String,
-    val status: PurchaseResultStatus = PurchaseResultStatus.SUCCESS,
+    val status: PurchaseResultStatus = PurchaseResultStatus.Success,
     val code: String? = null,
     val timestamp: Long = System.currentTimeMillis()
 )
 
-enum class PurchaseResultStatus { SUCCESS, INFO, ERROR }
+enum class PurchaseResultStatus { Success, Info, Error }
 
 data class ErrorData(
     val code: String,
@@ -382,5 +382,13 @@ data class IapOperation(
     val result: IapOperationResult? = null
 )
 
-enum class IapOperationType { INIT_CONNECTION, END_CONNECTION, FETCH_PRODUCTS, REQUEST_PURCHASE, FINISH_TRANSACTION, RESTORE_PURCHASES, VALIDATE_RECEIPT }
+enum class IapOperationType {
+    InitConnection,
+    EndConnection,
+    FetchProducts,
+    RequestPurchase,
+    FinishTransaction,
+    RestorePurchases,
+    ValidateReceipt,
+}
 sealed class IapOperationResult { object Success : IapOperationResult(); data class Failure(val message: String) : IapOperationResult(); object Cancelled : IapOperationResult() }

--- a/openiap/src/test/java/dev/hyo/openiap/OpenIapStoreTest.kt
+++ b/openiap/src/test/java/dev/hyo/openiap/OpenIapStoreTest.kt
@@ -97,7 +97,7 @@ class OpenIapStoreTest {
             purchaseToken = token,
             platform = "android",
             quantity = 1,
-            purchaseState = OpenIapPurchase.PurchaseState.PURCHASED,
+            purchaseState = OpenIapPurchase.PurchaseState.Purchased,
             isAutoRenewing = false,
             purchaseTokenAndroid = token,
             dataAndroid = null,
@@ -134,7 +134,7 @@ class OpenIapStoreTest {
 
         val result = store.requestPurchase(
             RequestPurchaseParams(skus = listOf("sku1")),
-            ProductRequest.ProductRequestType.INAPP
+            ProductRequest.ProductRequestType.InApp
         )
 
         assertEquals(1, result.size)

--- a/openiap/src/test/java/dev/hyo/openiap/models/ProductRequestTypeTest.kt
+++ b/openiap/src/test/java/dev/hyo/openiap/models/ProductRequestTypeTest.kt
@@ -1,0 +1,38 @@
+package dev.hyo.openiap.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProductRequestTypeTest {
+
+    @Test
+    fun productRequestType_acceptsHyphenAlias() {
+        val result = ProductRequest.ProductRequestType.fromString("in-app")
+        assertEquals(ProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun openIapProductRequestType_acceptsHyphenAlias() {
+        val result = OpenIapProductRequest.ProductRequestType.fromString("in-app")
+        assertEquals(OpenIapProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun productRequestType_handlesLegacyAliasUntilRemoval() {
+        val result = ProductRequest.ProductRequestType.fromString("inapp")
+        assertEquals(ProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun openIapProductRequestType_handlesLegacyAliasUntilRemoval() {
+        val result = OpenIapProductRequest.ProductRequestType.fromString("inapp")
+        assertEquals(OpenIapProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun productRequestTypes_exposeHyphenatedValue() {
+        assertEquals("in-app", ProductRequest.ProductRequestType.InApp.value)
+        assertEquals("in-app", OpenIapProductRequest.ProductRequestType.InApp.value)
+        assertEquals("in-app", OpenIapProduct.ProductType.InApp.value)
+    }
+}


### PR DESCRIPTION
## Summary

Standardizes in-app product identifiers to the hyphenated `in-app` value while preserving legacy alias handling across requests, models, docs, and tests. Replaces deprecated Compose helpers triggered by example build warnings.