### PR TITLE
refactor: standardize in-app naming

### DIFF
--- a/Example/src/main/java/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/AvailablePurchasesScreen.kt
@@ -77,12 +77,12 @@ fun AvailablePurchasesScreen(
                                     val restored = iapStore.restorePurchases()
                                     iapStore.postStatusMessage(
                                         message = "Restored ${restored.size} purchases",
-                                        status = PurchaseResultStatus.SUCCESS
+                                        status = PurchaseResultStatus.Success
                                     )
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Restore failed",
-                                        status = PurchaseResultStatus.ERROR
+                                        status = PurchaseResultStatus.Error
                                     )
                                 }
                             }
@@ -195,7 +195,7 @@ fun AvailablePurchasesScreen(
             // Check for unfinished transactions (purchases that need acknowledgment/consumption)
             val unfinishedPurchases = purchases.filter { purchase ->
                 // TODO: In real implementation, check if purchase needs acknowledgment/consumption
-                // This would typically check: purchase.purchaseState == PURCHASED && !purchase.isAcknowledged
+                // This would typically check: purchase.purchaseState == PurchaseState.Purchased && !purchase.isAcknowledged
                 // For demo purposes, let's assume some consumable purchases might need finishing
                 (purchase.productId.contains("consumable", ignoreCase = true) ||
                  purchase.productId.contains("bulb", ignoreCase = true)) && 
@@ -218,21 +218,21 @@ fun AvailablePurchasesScreen(
                                     if (ok) {
                                         iapStore.postStatusMessage(
                                             message = "Transaction finished successfully",
-                                            status = PurchaseResultStatus.SUCCESS,
+                                            status = PurchaseResultStatus.Success,
                                             productId = purchase.productId
                                         )
                                         iapStore.getAvailablePurchases()
                                     } else {
                                         iapStore.postStatusMessage(
                                             message = "Failed to finish transaction",
-                                            status = PurchaseResultStatus.ERROR,
+                                            status = PurchaseResultStatus.Error,
                                             productId = purchase.productId
                                         )
                                     }
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Failed to finish transaction",
-                                        status = PurchaseResultStatus.ERROR,
+                                        status = PurchaseResultStatus.Error,
                                         productId = purchase.productId
                                     )
                                 }
@@ -304,7 +304,7 @@ fun AvailablePurchasesScreen(
                 items(nonConsumables) { purchase ->
                     PurchaseItemCard(
                         purchase = purchase,
-                        type = PurchaseType.NON_CONSUMABLE,
+                        type = PurchaseType.NonConsumable,
                         onClick = { selectedPurchase = purchase }
                     )
                 }
@@ -319,7 +319,7 @@ fun AvailablePurchasesScreen(
                 items(consumables) { purchase ->
                     PurchaseItemCard(
                         purchase = purchase,
-                        type = PurchaseType.CONSUMABLE,
+                        type = PurchaseType.Consumable,
                         onClick = { selectedPurchase = purchase }
                     )
                 }
@@ -412,12 +412,12 @@ fun AvailablePurchasesScreen(
                                     val restored = iapStore.restorePurchases()
                                     iapStore.postStatusMessage(
                                         message = "Restored ${restored.size} purchases",
-                                        status = PurchaseResultStatus.SUCCESS
+                                        status = PurchaseResultStatus.Success
                                     )
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Restore failed",
-                                        status = PurchaseResultStatus.ERROR
+                                        status = PurchaseResultStatus.Error
                                     )
                                 }
                             }
@@ -444,9 +444,9 @@ fun AvailablePurchasesScreen(
 }
 
 enum class PurchaseType {
-    CONSUMABLE,
-    NON_CONSUMABLE,
-    SUBSCRIPTION
+    Consumable,
+    NonConsumable,
+    Subscription,
 }
 
 @Composable
@@ -456,17 +456,17 @@ fun PurchaseItemCard(
     onClick: () -> Unit
 ) {
     val (backgroundColor, iconColor, icon) = when (type) {
-        PurchaseType.SUBSCRIPTION -> Triple(
+        PurchaseType.Subscription -> Triple(
             AppColors.secondary.copy(alpha = 0.1f),
             AppColors.secondary,
             Icons.Default.Autorenew
         )
-        PurchaseType.NON_CONSUMABLE -> Triple(
+        PurchaseType.NonConsumable -> Triple(
             AppColors.success.copy(alpha = 0.1f),
             AppColors.success,
             Icons.Default.CheckCircle
         )
-        PurchaseType.CONSUMABLE -> Triple(
+        PurchaseType.Consumable -> Triple(
             AppColors.warning.copy(alpha = 0.1f),
             AppColors.warning,
             Icons.Default.Schedule

--- a/Example/src/main/java/dev/hyo/martie/screens/OfferCodeScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/OfferCodeScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -221,7 +222,7 @@ fun OfferCodeScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Icon(
-                            Icons.Default.HelpOutline,
+                            Icons.AutoMirrored.Filled.HelpOutline,
                             contentDescription = null,
                             tint = AppColors.primary
                         )

--- a/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/PurchaseFlowScreen.kt
@@ -65,7 +65,7 @@ fun PurchaseFlowScreen(
                     iapStore.setActivity(activity)
                     iapStore.fetchProducts(
                         skus = IapConstants.INAPP_SKUS,
-                        type = ProductRequest.ProductRequestType.INAPP
+                        type = ProductRequest.ProductRequestType.InApp
                     )
                     iapStore.getAvailablePurchases()
                 }
@@ -98,7 +98,7 @@ fun PurchaseFlowScreen(
                                     iapStore.setActivity(activity)
                                     iapStore.fetchProducts(
                                         skus = IapConstants.INAPP_SKUS,
-                                        type = ProductRequest.ProductRequestType.INAPP
+                                        type = ProductRequest.ProductRequestType.InApp
                                     )
                                 } catch (_: Exception) { }
                             }
@@ -187,7 +187,7 @@ fun PurchaseFlowScreen(
                             status = result.status,
                             onDismiss = { iapStore.clearStatusMessage() }
                         )
-                        if (result.status == PurchaseResultStatus.SUCCESS) {
+                        if (result.status == PurchaseResultStatus.Success) {
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -226,8 +226,8 @@ fun PurchaseFlowScreen(
                         isPurchasing = status.isPurchasing(product.id),
                         onPurchase = {
                             scope.launch {
-                                val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                                    ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                                val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                                    ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                                 iapStore.setActivity(activity)
                                 iapStore.requestPurchase(
                                     params = RequestPurchaseParams(skus = listOf(product.id)),
@@ -288,12 +288,12 @@ fun PurchaseFlowScreen(
                                     val restored = iapStore.restorePurchases()
                                     iapStore.postStatusMessage(
                                         message = "Restored ${restored.size} purchases",
-                                        status = PurchaseResultStatus.SUCCESS
+                                        status = PurchaseResultStatus.Success
                                     )
                                 } catch (e: Exception) {
                                     iapStore.postStatusMessage(
                                         message = e.message ?: "Restore failed",
-                                        status = PurchaseResultStatus.ERROR
+                                        status = PurchaseResultStatus.Error
                                     )
                                 }
                             }
@@ -312,7 +312,7 @@ fun PurchaseFlowScreen(
                                 try {
                                     iapStore.fetchProducts(
                                         skus = IapConstants.INAPP_SKUS,
-                                        type = ProductRequest.ProductRequestType.INAPP
+                                        type = ProductRequest.ProductRequestType.InApp
                                     )
                                 } catch (_: Exception) { }
                             }
@@ -346,7 +346,7 @@ fun PurchaseFlowScreen(
             if (!valid) {
                 iapStore.postStatusMessage(
                     message = "Receipt validation failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
                 return@LaunchedEffect
@@ -354,7 +354,7 @@ fun PurchaseFlowScreen(
             // 2) Determine consumable vs non-consumable
             val product = products.find { it.id == purchase.productId }
             val isConsumable = product?.let {
-                it.type == OpenIapProduct.ProductType.INAPP &&
+                it.type == OpenIapProduct.ProductType.InApp &&
                         (it.id.contains("consumable", true) || it.id.contains("bulb", true))
             } == true
 
@@ -372,14 +372,14 @@ fun PurchaseFlowScreen(
             if (!ok) {
                 iapStore.postStatusMessage(
                     message = "finishTransaction failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
             } else {
                 iapStore.loadPurchases()
                 iapStore.postStatusMessage(
                     message = "Purchase finished successfully",
-                    status = PurchaseResultStatus.SUCCESS,
+                    status = PurchaseResultStatus.Success,
                     productId = purchase.productId
                 )
                 selectedProduct = null
@@ -387,7 +387,7 @@ fun PurchaseFlowScreen(
         } catch (e: Exception) {
             iapStore.postStatusMessage(
                 message = e.message ?: "Failed to finish purchase",
-                status = PurchaseResultStatus.ERROR,
+                status = PurchaseResultStatus.Error,
                 productId = purchase.productId
             )
         }
@@ -400,8 +400,8 @@ fun PurchaseFlowScreen(
             onDismiss = { selectedProduct = null },
             onPurchase = {
                 uiScope.launch {
-                    val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                        ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                    val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                        ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                     iapStore.setActivity(activity)
                     iapStore.requestPurchase(
                         params = RequestPurchaseParams(skus = listOf(product.id)),

--- a/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/SubscriptionFlowScreen.kt
@@ -121,7 +121,7 @@ fun SubscriptionFlowScreen(
                     println("SubscriptionFlow: Loading subscription products: ${IapConstants.SUBS_SKUS}")
                     iapStore.fetchProducts(
                         skus = IapConstants.SUBS_SKUS,
-                        type = ProductRequest.ProductRequestType.SUBS
+                        type = ProductRequest.ProductRequestType.Subs
                     )
                     iapStore.getAvailablePurchases()
                 }
@@ -155,7 +155,7 @@ fun SubscriptionFlowScreen(
                                     iapStore.setActivity(activity)
                                     iapStore.fetchProducts(
                                         skus = IapConstants.SUBS_SKUS,
-                                        type = ProductRequest.ProductRequestType.SUBS
+                                        type = ProductRequest.ProductRequestType.Subs
                                     )
                                 } catch (_: Exception) { }
                             }
@@ -285,21 +285,21 @@ fun SubscriptionFlowScreen(
                     ProductCard(
                         product = product,
                         isPurchasing = status.isPurchasing(product.id),
-                        isSubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.PURCHASED },
+                        isSubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.Purchased },
                         onPurchase = {
                             // Prevent re-purchase if already subscribed
-                            val alreadySubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.PURCHASED }
+                            val alreadySubscribed = purchases.any { it.productId == product.id && it.purchaseState == OpenIapPurchase.PurchaseState.Purchased }
                             if (alreadySubscribed) {
                                 iapStore.postStatusMessage(
                                     message = "Already subscribed to ${product.id}",
-                                    status = PurchaseResultStatus.INFO,
+                                    status = PurchaseResultStatus.Info,
                                     productId = product.id
                                 )
                                 return@ProductCard
                             }
                             scope.launch {
-                                val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                                    ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                                val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                                    ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                                 iapStore.setActivity(activity)
                                 iapStore.requestPurchase(
                                     params = RequestPurchaseParams(skus = listOf(product.id)),
@@ -385,7 +385,7 @@ fun SubscriptionFlowScreen(
             if (!valid) {
                 iapStore.postStatusMessage(
                     message = "Receipt validation failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
                 return@LaunchedEffect
@@ -393,7 +393,7 @@ fun SubscriptionFlowScreen(
             // 2) Determine consumable vs non-consumable (subs -> false)
             val product = products.find { it.id == purchase.productId }
             val isConsumable = product?.let {
-                it.type == OpenIapProduct.ProductType.INAPP &&
+                it.type == OpenIapProduct.ProductType.InApp &&
                         (it.id.contains("consumable", true) || it.id.contains("bulb", true))
             } == true
 
@@ -411,7 +411,7 @@ fun SubscriptionFlowScreen(
             if (!ok) {
                 iapStore.postStatusMessage(
                     message = "finishTransaction failed",
-                    status = PurchaseResultStatus.ERROR,
+                    status = PurchaseResultStatus.Error,
                     productId = purchase.productId
                 )
             } else {
@@ -420,7 +420,7 @@ fun SubscriptionFlowScreen(
         } catch (e: Exception) {
             iapStore.postStatusMessage(
                 message = e.message ?: "Failed to finish purchase",
-                status = PurchaseResultStatus.ERROR,
+                status = PurchaseResultStatus.Error,
                 productId = purchase.productId
             )
         }
@@ -433,8 +433,8 @@ fun SubscriptionFlowScreen(
             onDismiss = { selectedProduct = null },
             onPurchase = {
                 uiScope.launch {
-                    val reqType = if (product.type == OpenIapProduct.ProductType.SUBS)
-                        ProductRequest.ProductRequestType.SUBS else ProductRequest.ProductRequestType.INAPP
+                    val reqType = if (product.type == OpenIapProduct.ProductType.Subs)
+                        ProductRequest.ProductRequestType.Subs else ProductRequest.ProductRequestType.InApp
                     iapStore.setActivity(activity)
                     iapStore.requestPurchase(
                         params = RequestPurchaseParams(skus = listOf(product.id)),

--- a/Example/src/main/java/dev/hyo/martie/screens/uis/Modals.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/uis/Modals.kt
@@ -77,7 +77,7 @@ fun ProductDetailModal(
                     }
                 }
                 
-                Divider()
+                HorizontalDivider()
                 
                 // Product Info
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -126,7 +126,7 @@ fun ProductDetailModal(
                         Surface(
                             shape = RoundedCornerShape(8.dp),
                             color = when (product.type) {
-                                OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                                OpenIapProduct.ProductType.Subs -> AppColors.secondary
                                 else -> AppColors.primary
                             }.copy(alpha = 0.2f)
                         ) {
@@ -136,7 +136,7 @@ fun ProductDetailModal(
                                 style = MaterialTheme.typography.labelMedium,
                                 fontWeight = FontWeight.SemiBold,
                                 color = when (product.type) {
-                                    OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                                    OpenIapProduct.ProductType.Subs -> AppColors.secondary
                                     else -> AppColors.primary
                                 }
                             )
@@ -173,7 +173,7 @@ fun ProductDetailModal(
                         }
                         
                         product.oneTimePurchaseOfferDetailsAndroid?.let { offer ->
-                            Divider(modifier = Modifier.padding(vertical = 4.dp))
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                             Text(
                                 "One-Time Purchase Details",
                                 style = MaterialTheme.typography.labelLarge,
@@ -185,7 +185,7 @@ fun ProductDetailModal(
                         
                         product.subscriptionOfferDetailsAndroid?.let { offers ->
                             if (offers.isNotEmpty()) {
-                                Divider(modifier = Modifier.padding(vertical = 4.dp))
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                                 Text(
                                     "Subscription Offers",
                                     style = MaterialTheme.typography.labelLarge,
@@ -312,7 +312,7 @@ fun PurchaseDetailModal(
                     }
                 }
                 
-                Divider()
+                HorizontalDivider()
                 
                 // Purchase Status
                 Row(
@@ -322,16 +322,16 @@ fun PurchaseDetailModal(
                 ) {
                     Icon(
                         when (purchase.purchaseState) {
-                            OpenIapPurchase.PurchaseState.PURCHASED -> Icons.Default.CheckCircle
-                            OpenIapPurchase.PurchaseState.PENDING -> Icons.Default.Schedule
-                            OpenIapPurchase.PurchaseState.FAILED -> Icons.Default.Error
+                            OpenIapPurchase.PurchaseState.Purchased -> Icons.Default.CheckCircle
+                            OpenIapPurchase.PurchaseState.Pending -> Icons.Default.Schedule
+                            OpenIapPurchase.PurchaseState.Failed -> Icons.Default.Error
                             else -> Icons.Default.Info
                         },
                         contentDescription = null,
                         tint = when (purchase.purchaseState) {
-                            OpenIapPurchase.PurchaseState.PURCHASED -> AppColors.success
-                            OpenIapPurchase.PurchaseState.PENDING -> AppColors.warning
-                            OpenIapPurchase.PurchaseState.FAILED -> AppColors.danger
+                            OpenIapPurchase.PurchaseState.Purchased -> AppColors.success
+                            OpenIapPurchase.PurchaseState.Pending -> AppColors.warning
+                            OpenIapPurchase.PurchaseState.Failed -> AppColors.danger
                             else -> AppColors.info
                         },
                         modifier = Modifier.size(32.dp)
@@ -405,7 +405,7 @@ fun PurchaseDetailModal(
                     }
                     
                     // Android specific details
-                    Divider(modifier = Modifier.padding(vertical = 4.dp))
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                     Text(
                         "Android Details",
                         style = MaterialTheme.typography.labelLarge,
@@ -430,7 +430,7 @@ fun PurchaseDetailModal(
                     
                     // Token info
                     if (!purchase.purchaseToken.isNullOrEmpty()) {
-                        Divider(modifier = Modifier.padding(vertical = 4.dp))
+                        HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
                         Text(
                             "Token Information",
                             style = MaterialTheme.typography.labelLarge,

--- a/Example/src/main/java/dev/hyo/martie/screens/uis/ProductCard.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/uis/ProductCard.kt
@@ -65,7 +65,7 @@ fun ProductCard(
                     Surface(
                         shape = RoundedCornerShape(4.dp),
                         color = when (product.type) {
-                            OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                            OpenIapProduct.ProductType.Subs -> AppColors.secondary
                             else -> AppColors.primary
                         }.copy(alpha = 0.2f)
                     ) {
@@ -74,7 +74,7 @@ fun ProductCard(
                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
                             style = MaterialTheme.typography.labelSmall,
                             color = when (product.type) {
-                                OpenIapProduct.ProductType.SUBS -> AppColors.secondary
+                                OpenIapProduct.ProductType.Subs -> AppColors.secondary
                                 else -> AppColors.primary
                             }
                         )

--- a/Example/src/main/java/dev/hyo/martie/screens/uis/PurchaseResultCard.kt
+++ b/Example/src/main/java/dev/hyo/martie/screens/uis/PurchaseResultCard.kt
@@ -21,9 +21,9 @@ fun PurchaseResultCard(
     onDismiss: () -> Unit
 ) {
     val (background, contentColor, icon) = when (status) {
-        PurchaseResultStatus.SUCCESS -> Triple(AppColors.success.copy(alpha = 0.1f), AppColors.success, Icons.Default.CheckCircle)
-        PurchaseResultStatus.INFO -> Triple(AppColors.info.copy(alpha = 0.1f), AppColors.info, Icons.Default.Info)
-        PurchaseResultStatus.ERROR -> Triple(AppColors.danger.copy(alpha = 0.1f), AppColors.danger, Icons.Default.ErrorOutline)
+        PurchaseResultStatus.Success -> Triple(AppColors.success.copy(alpha = 0.1f), AppColors.success, Icons.Default.CheckCircle)
+        PurchaseResultStatus.Info -> Triple(AppColors.info.copy(alpha = 0.1f), AppColors.info, Icons.Default.Info)
+        PurchaseResultStatus.Error -> Triple(AppColors.danger.copy(alpha = 0.1f), AppColors.danger, Icons.Default.ErrorOutline)
     }
     Card(
         modifier = Modifier

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun handlePurchaseUpdate(purchase: OpenIapPurchase) {
         when (purchase.purchaseState) {
-            PurchaseState.PURCHASED -> {
+            PurchaseState.Purchased -> {
                 // Acknowledge or consume the purchase
                 lifecycleScope.launch {
                     try {
@@ -141,7 +141,7 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
             }
-            PurchaseState.PENDING -> {
+            PurchaseState.Pending -> {
                 // Purchase is pending (e.g., awaiting payment)
             }
             // Handle other states...
@@ -196,6 +196,8 @@ suspend fun getAvailableItemsByType(type: String): List<OpenIapPurchase>
 suspend fun acknowledgePurchase(purchaseToken: String): Boolean
 suspend fun consumePurchase(purchaseToken: String): Boolean
 ```
+
+> Note: Use `"in-app"` for in-app product types. The legacy alias `"inapp"` remains available for compatibility but will be removed in version 1.2.0.
 
 #### Store Information
 

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapLog.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapLog.kt
@@ -8,10 +8,10 @@ import java.util.concurrent.atomic.AtomicReference
  * OpenIAP logging utility (Android parity with Apple side).
  * - Toggleable via isEnabled
  * - Optional external handler integration
- * - Level-based routing (DEBUG/INFO/WARN/ERROR)
+ * - Level-based routing (Debug/Info/Warn/Error)
  */
 object OpenIapLog {
-    enum class Level { DEBUG, INFO, WARN, ERROR }
+    enum class Level { Debug, Info, Warn, Error }
 
     private val enabled = AtomicBoolean(false)
     private val defaultTagRef = AtomicReference("OpenIAP")
@@ -31,10 +31,10 @@ object OpenIapLog {
     fun defaultTag(): String = defaultTagRef.get()
 
     // Shorthand APIs (match Apple naming)
-    fun debug(message: String, tag: String = defaultTag()) = log(Level.DEBUG, message, null, tag)
-    fun info(message: String, tag: String = defaultTag()) = log(Level.INFO, message, null, tag)
-    fun warn(message: String, tag: String = defaultTag()) = log(Level.WARN, message, null, tag)
-    fun error(message: String, tr: Throwable? = null, tag: String = defaultTag()) = log(Level.ERROR, message, tr, tag)
+    fun debug(message: String, tag: String = defaultTag()) = log(Level.Debug, message, null, tag)
+    fun info(message: String, tag: String = defaultTag()) = log(Level.Info, message, null, tag)
+    fun warn(message: String, tag: String = defaultTag()) = log(Level.Warn, message, null, tag)
+    fun error(message: String, tr: Throwable? = null, tag: String = defaultTag()) = log(Level.Error, message, tr, tag)
 
     // Backwards-compat alias with Android Log-style letters
     fun d(message: String, tag: String = defaultTag()) = debug(message, tag)
@@ -50,10 +50,10 @@ object OpenIapLog {
             return
         }
         when (level) {
-            Level.DEBUG -> Log.d(tag, message)
-            Level.INFO -> Log.i(tag, message)
-            Level.WARN -> Log.w(tag, message)
-            Level.ERROR -> Log.e(tag, message, tr)
+            Level.Debug -> Log.d(tag, message)
+            Level.Info -> Log.i(tag, message)
+            Level.Warn -> Log.w(tag, message)
+            Level.Error -> Log.e(tag, message, tr)
         }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapModule.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapModule.kt
@@ -101,15 +101,15 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
             val products = mutableListOf<OpenIapProduct>()
 
             // Fetch in-app products if requested
-            if (params.type == ProductRequest.ProductRequestType.INAPP ||
-                params.type == ProductRequest.ProductRequestType.ALL) {
+            if (params.type == ProductRequest.ProductRequestType.InApp ||
+                params.type == ProductRequest.ProductRequestType.All) {
                 val inappProducts = queryProducts(params.skus, BillingClient.ProductType.INAPP)
                 products.addAll(inappProducts)
             }
 
             // Fetch subscription products if requested
-            if (params.type == ProductRequest.ProductRequestType.SUBS ||
-                params.type == ProductRequest.ProductRequestType.ALL) {
+            if (params.type == ProductRequest.ProductRequestType.Subs ||
+                params.type == ProductRequest.ProductRequestType.All) {
                 val subsProducts = queryProducts(params.skus, BillingClient.ProductType.SUBS)
                 products.addAll(subsProducts)
             }
@@ -139,7 +139,7 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
             currentPurchaseCallback = { result ->
                 continuation.resume(result.getOrElse { emptyList() })
             }
-            val desiredType = if (type == ProductRequest.ProductRequestType.SUBS)
+            val desiredType = if (type == ProductRequest.ProductRequestType.Subs)
                 BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
 
             val client = billingClient
@@ -172,7 +172,7 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
                 for (pd in detailsList) {
                     val builder = BillingFlowParams.ProductDetailsParams.newBuilder()
                         .setProductDetails(pd)
-                    if (type == ProductRequest.ProductRequestType.SUBS) {
+                    if (type == ProductRequest.ProductRequestType.Subs) {
                         val offerToken = pd.subscriptionOfferDetails?.firstOrNull()?.offerToken
                         if (offerToken.isNullOrEmpty()) {
                             Log.w(TAG, "No subscription offer available for ${pd.productId}")
@@ -341,7 +341,7 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
 
     override suspend fun getAvailableItems(type: ProductRequest.ProductRequestType): List<OpenIapPurchase> =
         withContext(Dispatchers.IO) {
-            val productType = if (type == ProductRequest.ProductRequestType.SUBS) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
+            val productType = if (type == ProductRequest.ProductRequestType.Subs) BillingClient.ProductType.SUBS else BillingClient.ProductType.INAPP
             queryPurchases(productType)
         }
     
@@ -616,8 +616,8 @@ class OpenIapModule(private val context: Context) : OpenIapProtocol, PurchasesUp
             title = productDetails.title,
             description = productDetails.description,
             type = if (productType == BillingClient.ProductType.SUBS)
-                OpenIapProduct.ProductType.SUBS
-            else OpenIapProduct.ProductType.INAPP,
+                OpenIapProduct.ProductType.Subs
+            else OpenIapProduct.ProductType.InApp,
             displayName = productDetails.name,
             displayPrice = displayPrice,
             currency = currency,

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapProtocol.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapProtocol.kt
@@ -66,7 +66,8 @@ interface OpenIapProtocol {
     ): Boolean
 
     /**
-     * Get available purchases filtered by type (inapp or subs).
+     * Get available purchases filtered by type (`"in-app"` or `"subs"`).
+     * Note: `"inapp"` remains available for compatibility but will be removed in 1.2.0.
      */
     suspend fun getAvailableItems(type: dev.hyo.openiap.models.ProductRequest.ProductRequestType): List<OpenIapPurchase>
 
@@ -77,12 +78,12 @@ interface OpenIapProtocol {
     /**
      * Request a purchase for products or subscriptions.
      * @param request Purchase request parameters
-     * @param type Product type ('inapp' | 'subs'), required for Android
+     * @param type Product type (`"in-app"` | `"subs"`). `"inapp"` is supported until 1.2.0 for backwards compatibility.
      * @return Purchase object if successful, null if cancelled
      */
     suspend fun requestPurchase(
         request: RequestPurchaseParams,
-        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.INAPP
+        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.InApp
     ): List<OpenIapPurchase>
     
     /**

--- a/openiap/src/main/java/dev/hyo/openiap/OpenIapViewModel.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/OpenIapViewModel.kt
@@ -22,13 +22,13 @@ class OpenIapViewModel(app: Application) : AndroidViewModel(app) {
     fun initConnection() { viewModelScope.launch { runCatching { store.initConnection() } } }
     fun endConnection() { viewModelScope.launch { runCatching { store.endConnection() } } }
 
-    fun fetchProducts(skus: List<String>, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.ALL) {
+    fun fetchProducts(skus: List<String>, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.All) {
         viewModelScope.launch { runCatching { store.fetchProducts(skus, type) } }
     }
 
     fun restorePurchases() { viewModelScope.launch { runCatching { store.restorePurchases() } } }
 
-    fun requestPurchase(params: RequestPurchaseParams, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.INAPP) {
+    fun requestPurchase(params: RequestPurchaseParams, type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.InApp) {
         viewModelScope.launch { runCatching { store.requestPurchase(params, type) } }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapEvent.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapEvent.kt
@@ -4,8 +4,7 @@ package dev.hyo.openiap.models
  * OpenIAP event identifiers (parity with Apple-side enum)
  */
 enum class OpenIapEvent {
-    PURCHASE_UPDATED,
-    PURCHASE_ERROR,
-    PROMOTED_PRODUCT_IOS
+    PurchaseUpdated,
+    PurchaseError,
+    PromotedProductIos,
 }
-

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProduct.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProduct.kt
@@ -23,12 +23,12 @@ data class OpenIapProduct(
     val subscriptionOfferDetailsAndroid: List<SubscriptionOfferDetail>? = null
 ) {
     enum class ProductType(val value: String) {
-        INAPP("inapp"),
-        SUBS("subs");
+        InApp("in-app"),
+        Subs("subs");
         
         companion object {
             fun fromString(value: String): ProductType = 
-                values().find { it.value == value } ?: INAPP
+                values().find { it.value == value } ?: InApp
         }
     }
 

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProductRequest.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapProductRequest.kt
@@ -5,16 +5,28 @@ package dev.hyo.openiap.models
  */
 data class OpenIapProductRequest(
     val skus: List<String>,
-    val type: ProductRequestType = ProductRequestType.INAPP
+    val type: ProductRequestType = ProductRequestType.InApp
 ) {
     enum class ProductRequestType(val value: String) {
-        INAPP("inapp"),
-        SUBS("subs"),
-        ALL("all");
+        InApp("in-app"),
+        Subs("subs"),
+        All("all");
 
         companion object {
-            fun fromString(value: String): ProductRequestType =
-                values().find { it.value == value } ?: INAPP
+            private val INAPP_ALIASES = setOf(
+                "in-app",
+                "inapp", // Legacy alias slated for removal in 1.2.0
+            )
+
+            fun fromString(value: String): ProductRequestType {
+                val normalized = value.lowercase()
+                return when {
+                    normalized in INAPP_ALIASES -> InApp
+                    normalized == Subs.value -> Subs
+                    normalized == All.value -> All
+                    else -> InApp
+                }
+            }
         }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapPurchase.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapPurchase.kt
@@ -30,22 +30,22 @@ data class OpenIapPurchase(
     val obfuscatedProfileIdAndroid: String? = null
 ) {
     enum class PurchaseState(val value: String) {
-        PENDING("pending"),
-        PURCHASED("purchased"),
-        FAILED("failed"),
-        RESTORED("restored"), // iOS only but keeping for compatibility
-        DEFERRED("deferred"), // iOS only but keeping for compatibility
-        UNKNOWN("unknown");
+        Pending("pending"),
+        Purchased("purchased"),
+        Failed("failed"),
+        Restored("restored"), // iOS only but keeping for compatibility
+        Deferred("deferred"), // iOS only but keeping for compatibility
+        Unknown("unknown");
         
         companion object {
             fun fromString(value: String): PurchaseState = 
-                values().find { it.value == value } ?: UNKNOWN
+                values().find { it.value == value } ?: Unknown
                 
             fun fromBillingClientState(state: Int): PurchaseState = when (state) {
-                0 -> UNKNOWN // UNSPECIFIED_STATE
-                1 -> PURCHASED
-                2 -> PENDING
-                else -> UNKNOWN
+                0 -> Unknown // UNSPECIFIED_STATE
+                1 -> Purchased
+                2 -> Pending
+                else -> Unknown
             }
         }
     }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapRequestTypes.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapRequestTypes.kt
@@ -52,16 +52,28 @@ data class PurchaseOptions(
  */
 data class ProductRequest(
     val skus: List<String>,
-    val type: ProductRequestType = ProductRequestType.INAPP
+    val type: ProductRequestType = ProductRequestType.InApp
 ) {
     enum class ProductRequestType(val value: String) {
-        INAPP("inapp"),
-        SUBS("subs"),
-        ALL("all");
+        InApp("in-app"),
+        Subs("subs"),
+        All("all");
 
         companion object {
-            fun fromString(value: String): ProductRequestType =
-                values().find { it.value == value } ?: INAPP
+            private val INAPP_ALIASES = setOf(
+                "in-app",
+                "inapp", // Legacy alias slated for removal in 1.2.0
+            )
+
+            fun fromString(value: String): ProductRequestType {
+                val normalized = value.lowercase()
+                return when {
+                    normalized in INAPP_ALIASES -> InApp
+                    normalized == Subs.value -> Subs
+                    normalized == All.value -> All
+                    else -> InApp
+                }
+            }
         }
     }
 }

--- a/openiap/src/main/java/dev/hyo/openiap/models/OpenIapValidationTypes.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/models/OpenIapValidationTypes.kt
@@ -15,7 +15,7 @@ data class ReceiptValidationResultAndroid(
     val gracePeriodEndDate: Long,
     val parentProductId: String,
     val productId: String,
-    val productType: String, // "inapp" or "subs"
+    val productType: String, // "in-app" or "subs" ("inapp" legacy support)
     val purchaseDate: Long,
     val quantity: Int,
     val receiptId: String,
@@ -39,4 +39,3 @@ data class ReceiptValidationProps(
         val isSub: Boolean = false
     )
 }
-

--- a/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/store/OpenIapStore.kt
@@ -48,7 +48,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
         _currentPurchase.value = purchase
         setStatusMessage(
             message = "Purchase successful",
-            status = PurchaseResultStatus.SUCCESS,
+            status = PurchaseResultStatus.Success,
             productId = purchase.productId,
             transactionId = purchase.id
         )
@@ -60,7 +60,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
             val message = OpenIapError.defaultMessage(OpenIapError.UserCancelled.CODE)
             setStatusMessage(
                 message = message,
-                status = PurchaseResultStatus.INFO,
+                status = PurchaseResultStatus.Info,
                 productId = pendingRequestProductId
             )
             _status.value = _status.value.copy(lastError = null)
@@ -71,7 +71,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
         val message = error.message?.takeIf { it.isNotBlank() } ?: OpenIapError.defaultMessage(code)
         setStatusMessage(
             message = message,
-            status = PurchaseResultStatus.ERROR,
+            status = PurchaseResultStatus.Error,
             productId = pendingRequestProductId,
             code = code
         )
@@ -138,7 +138,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     suspend fun fetchProducts(
         skus: List<String>,
-        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.ALL
+        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.All
     ): List<OpenIapProduct> {
         setLoading { it.fetchProducts = true }
         return try {
@@ -182,7 +182,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     // -------------------------------------------------------------------------
     suspend fun requestPurchase(
         params: RequestPurchaseParams,
-        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.INAPP
+        type: ProductRequest.ProductRequestType = ProductRequest.ProductRequestType.InApp
     ): List<OpenIapPurchase> {
         val skuForStatus = params.skus.firstOrNull()
         if (skuForStatus != null) {
@@ -248,7 +248,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
 
     private fun setError(message: String?) {
         val msg = message ?: "Operation failed"
-        setStatusMessage(msg, PurchaseResultStatus.ERROR)
+        setStatusMessage(msg, PurchaseResultStatus.Error)
         _status.value = _status.value.copy(lastError = message?.let {
             ErrorData(code = "ERROR", message = it)
         })
@@ -279,7 +279,7 @@ class OpenIapStore(private val module: OpenIapProtocol) {
     ) {
         setStatusMessage(message, status, productId)
         _status.value = _status.value.copy(
-            lastError = if (status == PurchaseResultStatus.ERROR) {
+            lastError = if (status == PurchaseResultStatus.Error) {
                 ErrorData(code = "ERROR", message = message)
             } else {
                 null
@@ -332,12 +332,12 @@ data class PurchaseResultData(
     val productId: String?,
     val transactionId: String?,
     val message: String,
-    val status: PurchaseResultStatus = PurchaseResultStatus.SUCCESS,
+    val status: PurchaseResultStatus = PurchaseResultStatus.Success,
     val code: String? = null,
     val timestamp: Long = System.currentTimeMillis()
 )
 
-enum class PurchaseResultStatus { SUCCESS, INFO, ERROR }
+enum class PurchaseResultStatus { Success, Info, Error }
 
 data class ErrorData(
     val code: String,
@@ -353,5 +353,13 @@ data class IapOperation(
     val result: IapOperationResult? = null
 )
 
-enum class IapOperationType { INIT_CONNECTION, END_CONNECTION, FETCH_PRODUCTS, REQUEST_PURCHASE, FINISH_TRANSACTION, RESTORE_PURCHASES, VALIDATE_RECEIPT }
+enum class IapOperationType {
+    InitConnection,
+    EndConnection,
+    FetchProducts,
+    RequestPurchase,
+    FinishTransaction,
+    RestorePurchases,
+    ValidateReceipt,
+}
 sealed class IapOperationResult { object Success : IapOperationResult(); data class Failure(val message: String) : IapOperationResult(); object Cancelled : IapOperationResult() }

--- a/openiap/src/test/java/dev/hyo/openiap/OpenIapStoreTest.kt
+++ b/openiap/src/test/java/dev/hyo/openiap/OpenIapStoreTest.kt
@@ -97,7 +97,7 @@ class OpenIapStoreTest {
             purchaseToken = token,
             platform = "android",
             quantity = 1,
-            purchaseState = OpenIapPurchase.PurchaseState.PURCHASED,
+            purchaseState = OpenIapPurchase.PurchaseState.Purchased,
             isAutoRenewing = false,
             purchaseTokenAndroid = token,
             dataAndroid = null,
@@ -134,7 +134,7 @@ class OpenIapStoreTest {
 
         val result = store.requestPurchase(
             RequestPurchaseParams(skus = listOf("sku1")),
-            ProductRequest.ProductRequestType.INAPP
+            ProductRequest.ProductRequestType.InApp
         )
 
         assertEquals(1, result.size)

--- a/openiap/src/test/java/dev/hyo/openiap/models/ProductRequestTypeTest.kt
+++ b/openiap/src/test/java/dev/hyo/openiap/models/ProductRequestTypeTest.kt
@@ -1,0 +1,38 @@
+package dev.hyo.openiap.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ProductRequestTypeTest {
+
+    @Test
+    fun productRequestType_acceptsHyphenAlias() {
+        val result = ProductRequest.ProductRequestType.fromString("in-app")
+        assertEquals(ProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun openIapProductRequestType_acceptsHyphenAlias() {
+        val result = OpenIapProductRequest.ProductRequestType.fromString("in-app")
+        assertEquals(OpenIapProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun productRequestType_handlesLegacyAliasUntilRemoval() {
+        val result = ProductRequest.ProductRequestType.fromString("inapp")
+        assertEquals(ProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun openIapProductRequestType_handlesLegacyAliasUntilRemoval() {
+        val result = OpenIapProductRequest.ProductRequestType.fromString("inapp")
+        assertEquals(OpenIapProductRequest.ProductRequestType.InApp, result)
+    }
+
+    @Test
+    fun productRequestTypes_exposeHyphenatedValue() {
+        assertEquals("in-app", ProductRequest.ProductRequestType.InApp.value)
+        assertEquals("in-app", OpenIapProductRequest.ProductRequestType.InApp.value)
+        assertEquals("in-app", OpenIapProduct.ProductType.InApp.value)
+    }
+}


### PR DESCRIPTION
Standardizes our in-app product identifiers to the hyphenated `in-app` value while keeping the legacy alias until removal. Updates enums, docs, tests, and sample UI code accordingly, including fixing the Compose deprecation warnings.
