### PR TITLE
Check generated Types.kt during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
             "build-tools;34.0.0"
           yes | sdkmanager --licenses
 
+      - name: Verify generated Types.kt is up to date
+        run: |
+          ./scripts/generate-types.sh
+          git diff --exit-code openiap/src/main/java/dev/hyo/openiap/Types.kt
+
       - name: Build library and example
         run: ./gradlew --stacktrace --no-daemon :openiap:build :Example:assembleDebug
-

--- a/openiap/src/main/java/dev/hyo/openiap/Types.kt
+++ b/openiap/src/main/java/dev/hyo/openiap/Types.kt
@@ -1,0 +1,2136 @@
+// ============================================================================
+// AUTO-GENERATED TYPES — DO NOT EDIT DIRECTLY
+// Run `npm run generate` after updating any *.graphql schema file.
+// ============================================================================
+
+@file:Suppress("unused")
+
+package dev.hyo.openiap
+
+// MARK: - Enums
+
+public enum class ErrorCode(val rawValue: String) {
+    Unknown("UNKNOWN"),
+    UserCancelled("USER_CANCELLED"),
+    UserError("USER_ERROR"),
+    ItemUnavailable("ITEM_UNAVAILABLE"),
+    RemoteError("REMOTE_ERROR"),
+    NetworkError("NETWORK_ERROR"),
+    ServiceError("SERVICE_ERROR"),
+    ReceiptFailed("RECEIPT_FAILED"),
+    ReceiptFinished("RECEIPT_FINISHED"),
+    ReceiptFinishedFailed("RECEIPT_FINISHED_FAILED"),
+    NotPrepared("NOT_PREPARED"),
+    NotEnded("NOT_ENDED"),
+    AlreadyOwned("ALREADY_OWNED"),
+    DeveloperError("DEVELOPER_ERROR"),
+    BillingResponseJsonParseError("BILLING_RESPONSE_JSON_PARSE_ERROR"),
+    DeferredPayment("DEFERRED_PAYMENT"),
+    Interrupted("INTERRUPTED"),
+    IapNotAvailable("IAP_NOT_AVAILABLE"),
+    PurchaseError("PURCHASE_ERROR"),
+    SyncError("SYNC_ERROR"),
+    TransactionValidationFailed("TRANSACTION_VALIDATION_FAILED"),
+    ActivityUnavailable("ACTIVITY_UNAVAILABLE"),
+    AlreadyPrepared("ALREADY_PREPARED"),
+    Pending("PENDING"),
+    ConnectionClosed("CONNECTION_CLOSED"),
+    InitConnection("INIT_CONNECTION"),
+    ServiceDisconnected("SERVICE_DISCONNECTED"),
+    QueryProduct("QUERY_PRODUCT"),
+    SkuNotFound("SKU_NOT_FOUND"),
+    SkuOfferMismatch("SKU_OFFER_MISMATCH"),
+    ItemNotOwned("ITEM_NOT_OWNED"),
+    BillingUnavailable("BILLING_UNAVAILABLE"),
+    FeatureNotSupported("FEATURE_NOT_SUPPORTED"),
+    EmptySkuList("EMPTY_SKU_LIST");
+
+    companion object {
+        fun fromJson(value: String): ErrorCode = when (value) {
+            "UNKNOWN" -> ErrorCode.Unknown
+            "USER_CANCELLED" -> ErrorCode.UserCancelled
+            "USER_ERROR" -> ErrorCode.UserError
+            "ITEM_UNAVAILABLE" -> ErrorCode.ItemUnavailable
+            "REMOTE_ERROR" -> ErrorCode.RemoteError
+            "NETWORK_ERROR" -> ErrorCode.NetworkError
+            "SERVICE_ERROR" -> ErrorCode.ServiceError
+            "RECEIPT_FAILED" -> ErrorCode.ReceiptFailed
+            "RECEIPT_FINISHED" -> ErrorCode.ReceiptFinished
+            "RECEIPT_FINISHED_FAILED" -> ErrorCode.ReceiptFinishedFailed
+            "NOT_PREPARED" -> ErrorCode.NotPrepared
+            "NOT_ENDED" -> ErrorCode.NotEnded
+            "ALREADY_OWNED" -> ErrorCode.AlreadyOwned
+            "DEVELOPER_ERROR" -> ErrorCode.DeveloperError
+            "BILLING_RESPONSE_JSON_PARSE_ERROR" -> ErrorCode.BillingResponseJsonParseError
+            "DEFERRED_PAYMENT" -> ErrorCode.DeferredPayment
+            "INTERRUPTED" -> ErrorCode.Interrupted
+            "IAP_NOT_AVAILABLE" -> ErrorCode.IapNotAvailable
+            "PURCHASE_ERROR" -> ErrorCode.PurchaseError
+            "SYNC_ERROR" -> ErrorCode.SyncError
+            "TRANSACTION_VALIDATION_FAILED" -> ErrorCode.TransactionValidationFailed
+            "ACTIVITY_UNAVAILABLE" -> ErrorCode.ActivityUnavailable
+            "ALREADY_PREPARED" -> ErrorCode.AlreadyPrepared
+            "PENDING" -> ErrorCode.Pending
+            "CONNECTION_CLOSED" -> ErrorCode.ConnectionClosed
+            "INIT_CONNECTION" -> ErrorCode.InitConnection
+            "SERVICE_DISCONNECTED" -> ErrorCode.ServiceDisconnected
+            "QUERY_PRODUCT" -> ErrorCode.QueryProduct
+            "SKU_NOT_FOUND" -> ErrorCode.SkuNotFound
+            "SKU_OFFER_MISMATCH" -> ErrorCode.SkuOfferMismatch
+            "ITEM_NOT_OWNED" -> ErrorCode.ItemNotOwned
+            "BILLING_UNAVAILABLE" -> ErrorCode.BillingUnavailable
+            "FEATURE_NOT_SUPPORTED" -> ErrorCode.FeatureNotSupported
+            "EMPTY_SKU_LIST" -> ErrorCode.EmptySkuList
+            else -> throw IllegalArgumentException("Unknown ErrorCode value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class IapEvent(val rawValue: String) {
+    PurchaseUpdated("PURCHASE_UPDATED"),
+    PurchaseError("PURCHASE_ERROR"),
+    PromotedProductIos("PROMOTED_PRODUCT_IOS");
+
+    companion object {
+        fun fromJson(value: String): IapEvent = when (value) {
+            "PURCHASE_UPDATED" -> IapEvent.PurchaseUpdated
+            "PURCHASE_ERROR" -> IapEvent.PurchaseError
+            "PROMOTED_PRODUCT_IOS" -> IapEvent.PromotedProductIos
+            else -> throw IllegalArgumentException("Unknown IapEvent value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class IapPlatform(val rawValue: String) {
+    Ios("IOS"),
+    Android("ANDROID");
+
+    companion object {
+        fun fromJson(value: String): IapPlatform = when (value) {
+            "IOS" -> IapPlatform.Ios
+            "ANDROID" -> IapPlatform.Android
+            else -> throw IllegalArgumentException("Unknown IapPlatform value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class PaymentModeIOS(val rawValue: String) {
+    Empty("EMPTY"),
+    FreeTrial("FREE_TRIAL"),
+    PayAsYouGo("PAY_AS_YOU_GO"),
+    PayUpFront("PAY_UP_FRONT");
+
+    companion object {
+        fun fromJson(value: String): PaymentModeIOS = when (value) {
+            "EMPTY" -> PaymentModeIOS.Empty
+            "FREE_TRIAL" -> PaymentModeIOS.FreeTrial
+            "PAY_AS_YOU_GO" -> PaymentModeIOS.PayAsYouGo
+            "PAY_UP_FRONT" -> PaymentModeIOS.PayUpFront
+            else -> throw IllegalArgumentException("Unknown PaymentModeIOS value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class ProductQueryType(val rawValue: String) {
+    InApp("IN_APP"),
+    Subs("SUBS"),
+    All("ALL");
+
+    companion object {
+        fun fromJson(value: String): ProductQueryType = when (value) {
+            "IN_APP" -> ProductQueryType.InApp
+            "SUBS" -> ProductQueryType.Subs
+            "ALL" -> ProductQueryType.All
+            else -> throw IllegalArgumentException("Unknown ProductQueryType value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class ProductType(val rawValue: String) {
+    InApp("IN_APP"),
+    Subs("SUBS");
+
+    companion object {
+        fun fromJson(value: String): ProductType = when (value) {
+            "IN_APP" -> ProductType.InApp
+            "SUBS" -> ProductType.Subs
+            else -> throw IllegalArgumentException("Unknown ProductType value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class ProductTypeIOS(val rawValue: String) {
+    Consumable("CONSUMABLE"),
+    NonConsumable("NON_CONSUMABLE"),
+    AutoRenewableSubscription("AUTO_RENEWABLE_SUBSCRIPTION"),
+    NonRenewingSubscription("NON_RENEWING_SUBSCRIPTION");
+
+    companion object {
+        fun fromJson(value: String): ProductTypeIOS = when (value) {
+            "CONSUMABLE" -> ProductTypeIOS.Consumable
+            "NON_CONSUMABLE" -> ProductTypeIOS.NonConsumable
+            "AUTO_RENEWABLE_SUBSCRIPTION" -> ProductTypeIOS.AutoRenewableSubscription
+            "NON_RENEWING_SUBSCRIPTION" -> ProductTypeIOS.NonRenewingSubscription
+            else -> throw IllegalArgumentException("Unknown ProductTypeIOS value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class PurchaseState(val rawValue: String) {
+    Pending("PENDING"),
+    Purchased("PURCHASED"),
+    Failed("FAILED"),
+    Restored("RESTORED"),
+    Deferred("DEFERRED"),
+    Unknown("UNKNOWN");
+
+    companion object {
+        fun fromJson(value: String): PurchaseState = when (value) {
+            "PENDING" -> PurchaseState.Pending
+            "PURCHASED" -> PurchaseState.Purchased
+            "FAILED" -> PurchaseState.Failed
+            "RESTORED" -> PurchaseState.Restored
+            "DEFERRED" -> PurchaseState.Deferred
+            "UNKNOWN" -> PurchaseState.Unknown
+            else -> throw IllegalArgumentException("Unknown PurchaseState value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class SubscriptionOfferTypeIOS(val rawValue: String) {
+    Introductory("INTRODUCTORY"),
+    Promotional("PROMOTIONAL");
+
+    companion object {
+        fun fromJson(value: String): SubscriptionOfferTypeIOS = when (value) {
+            "INTRODUCTORY" -> SubscriptionOfferTypeIOS.Introductory
+            "PROMOTIONAL" -> SubscriptionOfferTypeIOS.Promotional
+            else -> throw IllegalArgumentException("Unknown SubscriptionOfferTypeIOS value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+public enum class SubscriptionPeriodIOS(val rawValue: String) {
+    Day("DAY"),
+    Week("WEEK"),
+    Month("MONTH"),
+    Year("YEAR"),
+    Empty("EMPTY");
+
+    companion object {
+        fun fromJson(value: String): SubscriptionPeriodIOS = when (value) {
+            "DAY" -> SubscriptionPeriodIOS.Day
+            "WEEK" -> SubscriptionPeriodIOS.Week
+            "MONTH" -> SubscriptionPeriodIOS.Month
+            "YEAR" -> SubscriptionPeriodIOS.Year
+            "EMPTY" -> SubscriptionPeriodIOS.Empty
+            else -> throw IllegalArgumentException("Unknown SubscriptionPeriodIOS value: $value")
+        }
+    }
+
+    fun toJson(): String = rawValue
+}
+
+// MARK: - Interfaces
+
+public interface ProductCommon {
+    val currency: String
+    val debugDescription: String?
+    val description: String
+    val displayName: String?
+    val displayPrice: String
+    val id: String
+    val platform: IapPlatform
+    val price: Double?
+    val title: String
+    val type: ProductType
+}
+
+public interface PurchaseCommon {
+    val id: String
+    val ids: List<String>?
+    val isAutoRenewing: Boolean
+    val platform: IapPlatform
+    val productId: String
+    val purchaseState: PurchaseState
+    /**
+     * Unified purchase token (iOS JWS, Android purchaseToken)
+     */
+    val purchaseToken: String?
+    val quantity: Int
+    val transactionDate: Double
+}
+
+// MARK: - Objects
+
+public data class ActiveSubscription(
+    val autoRenewingAndroid: Boolean? = null,
+    val daysUntilExpirationIOS: Double? = null,
+    val environmentIOS: String? = null,
+    val expirationDateIOS: Double? = null,
+    val isActive: Boolean,
+    val productId: String,
+    val purchaseToken: String? = null,
+    val transactionDate: Double,
+    val transactionId: String,
+    val willExpireSoon: Boolean? = null
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ActiveSubscription {
+            return ActiveSubscription(
+                autoRenewingAndroid = json["autoRenewingAndroid"] as Boolean?,
+                daysUntilExpirationIOS = (json["daysUntilExpirationIOS"] as Number?)?.toDouble(),
+                environmentIOS = json["environmentIOS"] as String?,
+                expirationDateIOS = (json["expirationDateIOS"] as Number?)?.toDouble(),
+                isActive = json["isActive"] as Boolean,
+                productId = json["productId"] as String,
+                purchaseToken = json["purchaseToken"] as String?,
+                transactionDate = (json["transactionDate"] as Number).toDouble(),
+                transactionId = json["transactionId"] as String,
+                willExpireSoon = json["willExpireSoon"] as Boolean?,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ActiveSubscription",
+        "autoRenewingAndroid" to autoRenewingAndroid,
+        "daysUntilExpirationIOS" to daysUntilExpirationIOS,
+        "environmentIOS" to environmentIOS,
+        "expirationDateIOS" to expirationDateIOS,
+        "isActive" to isActive,
+        "productId" to productId,
+        "purchaseToken" to purchaseToken,
+        "transactionDate" to transactionDate,
+        "transactionId" to transactionId,
+        "willExpireSoon" to willExpireSoon,
+    )
+}
+
+public data class AppTransaction(
+    val appId: Double,
+    val appTransactionId: String? = null,
+    val appVersion: String,
+    val appVersionId: Double,
+    val bundleId: String,
+    val deviceVerification: String,
+    val deviceVerificationNonce: String,
+    val environment: String,
+    val originalAppVersion: String,
+    val originalPlatform: String? = null,
+    val originalPurchaseDate: Double,
+    val preorderDate: Double? = null,
+    val signedDate: Double
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): AppTransaction {
+            return AppTransaction(
+                appId = (json["appId"] as Number).toDouble(),
+                appTransactionId = json["appTransactionId"] as String?,
+                appVersion = json["appVersion"] as String,
+                appVersionId = (json["appVersionId"] as Number).toDouble(),
+                bundleId = json["bundleId"] as String,
+                deviceVerification = json["deviceVerification"] as String,
+                deviceVerificationNonce = json["deviceVerificationNonce"] as String,
+                environment = json["environment"] as String,
+                originalAppVersion = json["originalAppVersion"] as String,
+                originalPlatform = json["originalPlatform"] as String?,
+                originalPurchaseDate = (json["originalPurchaseDate"] as Number).toDouble(),
+                preorderDate = (json["preorderDate"] as Number?)?.toDouble(),
+                signedDate = (json["signedDate"] as Number).toDouble(),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "AppTransaction",
+        "appId" to appId,
+        "appTransactionId" to appTransactionId,
+        "appVersion" to appVersion,
+        "appVersionId" to appVersionId,
+        "bundleId" to bundleId,
+        "deviceVerification" to deviceVerification,
+        "deviceVerificationNonce" to deviceVerificationNonce,
+        "environment" to environment,
+        "originalAppVersion" to originalAppVersion,
+        "originalPlatform" to originalPlatform,
+        "originalPurchaseDate" to originalPurchaseDate,
+        "preorderDate" to preorderDate,
+        "signedDate" to signedDate,
+    )
+}
+
+public data class DiscountIOS(
+    val identifier: String,
+    val localizedPrice: String? = null,
+    val numberOfPeriods: Int,
+    val paymentMode: PaymentModeIOS,
+    val price: String,
+    val priceAmount: Double,
+    val subscriptionPeriod: String,
+    val type: String
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): DiscountIOS {
+            return DiscountIOS(
+                identifier = json["identifier"] as String,
+                localizedPrice = json["localizedPrice"] as String?,
+                numberOfPeriods = (json["numberOfPeriods"] as Number).toInt(),
+                paymentMode = PaymentModeIOS.fromJson(json["paymentMode"] as String),
+                price = json["price"] as String,
+                priceAmount = (json["priceAmount"] as Number).toDouble(),
+                subscriptionPeriod = json["subscriptionPeriod"] as String,
+                type = json["type"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "DiscountIOS",
+        "identifier" to identifier,
+        "localizedPrice" to localizedPrice,
+        "numberOfPeriods" to numberOfPeriods,
+        "paymentMode" to paymentMode.toJson(),
+        "price" to price,
+        "priceAmount" to priceAmount,
+        "subscriptionPeriod" to subscriptionPeriod,
+        "type" to type,
+    )
+}
+
+public data class DiscountOfferIOS(
+    /**
+     * Discount identifier
+     */
+    val identifier: String,
+    /**
+     * Key identifier for validation
+     */
+    val keyIdentifier: String,
+    /**
+     * Cryptographic nonce
+     */
+    val nonce: String,
+    /**
+     * Signature for validation
+     */
+    val signature: String,
+    /**
+     * Timestamp of discount offer
+     */
+    val timestamp: Double
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): DiscountOfferIOS {
+            return DiscountOfferIOS(
+                identifier = json["identifier"] as String,
+                keyIdentifier = json["keyIdentifier"] as String,
+                nonce = json["nonce"] as String,
+                signature = json["signature"] as String,
+                timestamp = (json["timestamp"] as Number).toDouble(),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "DiscountOfferIOS",
+        "identifier" to identifier,
+        "keyIdentifier" to keyIdentifier,
+        "nonce" to nonce,
+        "signature" to signature,
+        "timestamp" to timestamp,
+    )
+}
+
+public data class EntitlementIOS(
+    val jsonRepresentation: String,
+    val sku: String,
+    val transactionId: String
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): EntitlementIOS {
+            return EntitlementIOS(
+                jsonRepresentation = json["jsonRepresentation"] as String,
+                sku = json["sku"] as String,
+                transactionId = json["transactionId"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "EntitlementIOS",
+        "jsonRepresentation" to jsonRepresentation,
+        "sku" to sku,
+        "transactionId" to transactionId,
+    )
+}
+
+public sealed interface FetchProductsResult
+
+public data class FetchProductsResultProducts(val value: List<Product>?) : FetchProductsResult
+
+public data class FetchProductsResultSubscriptions(val value: List<ProductSubscription>?) : FetchProductsResult
+
+public data class PricingPhaseAndroid(
+    val billingCycleCount: Int,
+    val billingPeriod: String,
+    val formattedPrice: String,
+    val priceAmountMicros: String,
+    val priceCurrencyCode: String,
+    val recurrenceMode: Int
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PricingPhaseAndroid {
+            return PricingPhaseAndroid(
+                billingCycleCount = (json["billingCycleCount"] as Number).toInt(),
+                billingPeriod = json["billingPeriod"] as String,
+                formattedPrice = json["formattedPrice"] as String,
+                priceAmountMicros = json["priceAmountMicros"] as String,
+                priceCurrencyCode = json["priceCurrencyCode"] as String,
+                recurrenceMode = (json["recurrenceMode"] as Number).toInt(),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "PricingPhaseAndroid",
+        "billingCycleCount" to billingCycleCount,
+        "billingPeriod" to billingPeriod,
+        "formattedPrice" to formattedPrice,
+        "priceAmountMicros" to priceAmountMicros,
+        "priceCurrencyCode" to priceCurrencyCode,
+        "recurrenceMode" to recurrenceMode,
+    )
+}
+
+public data class PricingPhasesAndroid(
+    val pricingPhaseList: List<PricingPhaseAndroid>
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PricingPhasesAndroid {
+            return PricingPhasesAndroid(
+                pricingPhaseList = (json["pricingPhaseList"] as List<*>).map { PricingPhaseAndroid.fromJson((it as Map<String, Any?>)) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "PricingPhasesAndroid",
+        "pricingPhaseList" to pricingPhaseList.map { it.toJson() },
+    )
+}
+
+public data class ProductAndroid(
+    override val currency: String,
+    override val debugDescription: String? = null,
+    override val description: String,
+    override val displayName: String? = null,
+    override val displayPrice: String,
+    override val id: String,
+    val nameAndroid: String,
+    val oneTimePurchaseOfferDetailsAndroid: ProductAndroidOneTimePurchaseOfferDetail? = null,
+    override val platform: IapPlatform,
+    override val price: Double? = null,
+    val subscriptionOfferDetailsAndroid: List<ProductSubscriptionAndroidOfferDetails>? = null,
+    override val title: String,
+    override val type: ProductType
+) : ProductCommon, Product {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductAndroid {
+            return ProductAndroid(
+                currency = json["currency"] as String,
+                debugDescription = json["debugDescription"] as String?,
+                description = json["description"] as String,
+                displayName = json["displayName"] as String?,
+                displayPrice = json["displayPrice"] as String,
+                id = json["id"] as String,
+                nameAndroid = json["nameAndroid"] as String,
+                oneTimePurchaseOfferDetailsAndroid = (json["oneTimePurchaseOfferDetailsAndroid"] as Map<String, Any?>?)?.let { ProductAndroidOneTimePurchaseOfferDetail.fromJson(it) },
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                price = (json["price"] as Number?)?.toDouble(),
+                subscriptionOfferDetailsAndroid = (json["subscriptionOfferDetailsAndroid"] as List<*>?)?.map { ProductSubscriptionAndroidOfferDetails.fromJson((it as Map<String, Any?>)) },
+                title = json["title"] as String,
+                type = ProductType.fromJson(json["type"] as String),
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ProductAndroid",
+        "currency" to currency,
+        "debugDescription" to debugDescription,
+        "description" to description,
+        "displayName" to displayName,
+        "displayPrice" to displayPrice,
+        "id" to id,
+        "nameAndroid" to nameAndroid,
+        "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseOfferDetailsAndroid?.toJson(),
+        "platform" to platform.toJson(),
+        "price" to price,
+        "subscriptionOfferDetailsAndroid" to subscriptionOfferDetailsAndroid?.map { it.toJson() },
+        "title" to title,
+        "type" to type.toJson(),
+    )
+}
+
+public data class ProductAndroidOneTimePurchaseOfferDetail(
+    val formattedPrice: String,
+    val priceAmountMicros: String,
+    val priceCurrencyCode: String
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductAndroidOneTimePurchaseOfferDetail {
+            return ProductAndroidOneTimePurchaseOfferDetail(
+                formattedPrice = json["formattedPrice"] as String,
+                priceAmountMicros = json["priceAmountMicros"] as String,
+                priceCurrencyCode = json["priceCurrencyCode"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ProductAndroidOneTimePurchaseOfferDetail",
+        "formattedPrice" to formattedPrice,
+        "priceAmountMicros" to priceAmountMicros,
+        "priceCurrencyCode" to priceCurrencyCode,
+    )
+}
+
+public data class ProductIOS(
+    override val currency: String,
+    override val debugDescription: String? = null,
+    override val description: String,
+    override val displayName: String? = null,
+    val displayNameIOS: String,
+    override val displayPrice: String,
+    override val id: String,
+    val isFamilyShareableIOS: Boolean,
+    val jsonRepresentationIOS: String,
+    override val platform: IapPlatform,
+    override val price: Double? = null,
+    val subscriptionInfoIOS: SubscriptionInfoIOS? = null,
+    override val title: String,
+    override val type: ProductType,
+    val typeIOS: ProductTypeIOS
+) : ProductCommon, Product {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductIOS {
+            return ProductIOS(
+                currency = json["currency"] as String,
+                debugDescription = json["debugDescription"] as String?,
+                description = json["description"] as String,
+                displayName = json["displayName"] as String?,
+                displayNameIOS = json["displayNameIOS"] as String,
+                displayPrice = json["displayPrice"] as String,
+                id = json["id"] as String,
+                isFamilyShareableIOS = json["isFamilyShareableIOS"] as Boolean,
+                jsonRepresentationIOS = json["jsonRepresentationIOS"] as String,
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                price = (json["price"] as Number?)?.toDouble(),
+                subscriptionInfoIOS = (json["subscriptionInfoIOS"] as Map<String, Any?>?)?.let { SubscriptionInfoIOS.fromJson(it) },
+                title = json["title"] as String,
+                type = ProductType.fromJson(json["type"] as String),
+                typeIOS = ProductTypeIOS.fromJson(json["typeIOS"] as String),
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ProductIOS",
+        "currency" to currency,
+        "debugDescription" to debugDescription,
+        "description" to description,
+        "displayName" to displayName,
+        "displayNameIOS" to displayNameIOS,
+        "displayPrice" to displayPrice,
+        "id" to id,
+        "isFamilyShareableIOS" to isFamilyShareableIOS,
+        "jsonRepresentationIOS" to jsonRepresentationIOS,
+        "platform" to platform.toJson(),
+        "price" to price,
+        "subscriptionInfoIOS" to subscriptionInfoIOS?.toJson(),
+        "title" to title,
+        "type" to type.toJson(),
+        "typeIOS" to typeIOS.toJson(),
+    )
+}
+
+public data class ProductSubscriptionAndroid(
+    override val currency: String,
+    override val debugDescription: String? = null,
+    override val description: String,
+    override val displayName: String? = null,
+    override val displayPrice: String,
+    override val id: String,
+    val nameAndroid: String,
+    val oneTimePurchaseOfferDetailsAndroid: ProductAndroidOneTimePurchaseOfferDetail? = null,
+    override val platform: IapPlatform,
+    override val price: Double? = null,
+    val subscriptionOfferDetailsAndroid: List<ProductSubscriptionAndroidOfferDetails>,
+    override val title: String,
+    override val type: ProductType
+) : ProductCommon, ProductSubscription {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductSubscriptionAndroid {
+            return ProductSubscriptionAndroid(
+                currency = json["currency"] as String,
+                debugDescription = json["debugDescription"] as String?,
+                description = json["description"] as String,
+                displayName = json["displayName"] as String?,
+                displayPrice = json["displayPrice"] as String,
+                id = json["id"] as String,
+                nameAndroid = json["nameAndroid"] as String,
+                oneTimePurchaseOfferDetailsAndroid = (json["oneTimePurchaseOfferDetailsAndroid"] as Map<String, Any?>?)?.let { ProductAndroidOneTimePurchaseOfferDetail.fromJson(it) },
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                price = (json["price"] as Number?)?.toDouble(),
+                subscriptionOfferDetailsAndroid = (json["subscriptionOfferDetailsAndroid"] as List<*>).map { ProductSubscriptionAndroidOfferDetails.fromJson((it as Map<String, Any?>)) },
+                title = json["title"] as String,
+                type = ProductType.fromJson(json["type"] as String),
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ProductSubscriptionAndroid",
+        "currency" to currency,
+        "debugDescription" to debugDescription,
+        "description" to description,
+        "displayName" to displayName,
+        "displayPrice" to displayPrice,
+        "id" to id,
+        "nameAndroid" to nameAndroid,
+        "oneTimePurchaseOfferDetailsAndroid" to oneTimePurchaseOfferDetailsAndroid?.toJson(),
+        "platform" to platform.toJson(),
+        "price" to price,
+        "subscriptionOfferDetailsAndroid" to subscriptionOfferDetailsAndroid.map { it.toJson() },
+        "title" to title,
+        "type" to type.toJson(),
+    )
+}
+
+public data class ProductSubscriptionAndroidOfferDetails(
+    val basePlanId: String,
+    val offerId: String? = null,
+    val offerTags: List<String>,
+    val offerToken: String,
+    val pricingPhases: PricingPhasesAndroid
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductSubscriptionAndroidOfferDetails {
+            return ProductSubscriptionAndroidOfferDetails(
+                basePlanId = json["basePlanId"] as String,
+                offerId = json["offerId"] as String?,
+                offerTags = (json["offerTags"] as List<*>).map { it as String },
+                offerToken = json["offerToken"] as String,
+                pricingPhases = PricingPhasesAndroid.fromJson((json["pricingPhases"] as Map<String, Any?>)),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ProductSubscriptionAndroidOfferDetails",
+        "basePlanId" to basePlanId,
+        "offerId" to offerId,
+        "offerTags" to offerTags.map { it },
+        "offerToken" to offerToken,
+        "pricingPhases" to pricingPhases.toJson(),
+    )
+}
+
+public data class ProductSubscriptionIOS(
+    override val currency: String,
+    override val debugDescription: String? = null,
+    override val description: String,
+    val discountsIOS: List<DiscountIOS>? = null,
+    override val displayName: String? = null,
+    val displayNameIOS: String,
+    override val displayPrice: String,
+    override val id: String,
+    val introductoryPriceAsAmountIOS: String? = null,
+    val introductoryPriceIOS: String? = null,
+    val introductoryPriceNumberOfPeriodsIOS: String? = null,
+    val introductoryPricePaymentModeIOS: PaymentModeIOS? = null,
+    val introductoryPriceSubscriptionPeriodIOS: SubscriptionPeriodIOS? = null,
+    val isFamilyShareableIOS: Boolean,
+    val jsonRepresentationIOS: String,
+    override val platform: IapPlatform,
+    override val price: Double? = null,
+    val subscriptionInfoIOS: SubscriptionInfoIOS? = null,
+    val subscriptionPeriodNumberIOS: String? = null,
+    val subscriptionPeriodUnitIOS: SubscriptionPeriodIOS? = null,
+    override val title: String,
+    override val type: ProductType,
+    val typeIOS: ProductTypeIOS
+) : ProductCommon, ProductSubscription {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductSubscriptionIOS {
+            return ProductSubscriptionIOS(
+                currency = json["currency"] as String,
+                debugDescription = json["debugDescription"] as String?,
+                description = json["description"] as String,
+                discountsIOS = (json["discountsIOS"] as List<*>?)?.map { DiscountIOS.fromJson((it as Map<String, Any?>)) },
+                displayName = json["displayName"] as String?,
+                displayNameIOS = json["displayNameIOS"] as String,
+                displayPrice = json["displayPrice"] as String,
+                id = json["id"] as String,
+                introductoryPriceAsAmountIOS = json["introductoryPriceAsAmountIOS"] as String?,
+                introductoryPriceIOS = json["introductoryPriceIOS"] as String?,
+                introductoryPriceNumberOfPeriodsIOS = json["introductoryPriceNumberOfPeriodsIOS"] as String?,
+                introductoryPricePaymentModeIOS = (json["introductoryPricePaymentModeIOS"] as String?)?.let { PaymentModeIOS.fromJson(it) },
+                introductoryPriceSubscriptionPeriodIOS = (json["introductoryPriceSubscriptionPeriodIOS"] as String?)?.let { SubscriptionPeriodIOS.fromJson(it) },
+                isFamilyShareableIOS = json["isFamilyShareableIOS"] as Boolean,
+                jsonRepresentationIOS = json["jsonRepresentationIOS"] as String,
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                price = (json["price"] as Number?)?.toDouble(),
+                subscriptionInfoIOS = (json["subscriptionInfoIOS"] as Map<String, Any?>?)?.let { SubscriptionInfoIOS.fromJson(it) },
+                subscriptionPeriodNumberIOS = json["subscriptionPeriodNumberIOS"] as String?,
+                subscriptionPeriodUnitIOS = (json["subscriptionPeriodUnitIOS"] as String?)?.let { SubscriptionPeriodIOS.fromJson(it) },
+                title = json["title"] as String,
+                type = ProductType.fromJson(json["type"] as String),
+                typeIOS = ProductTypeIOS.fromJson(json["typeIOS"] as String),
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ProductSubscriptionIOS",
+        "currency" to currency,
+        "debugDescription" to debugDescription,
+        "description" to description,
+        "discountsIOS" to discountsIOS?.map { it.toJson() },
+        "displayName" to displayName,
+        "displayNameIOS" to displayNameIOS,
+        "displayPrice" to displayPrice,
+        "id" to id,
+        "introductoryPriceAsAmountIOS" to introductoryPriceAsAmountIOS,
+        "introductoryPriceIOS" to introductoryPriceIOS,
+        "introductoryPriceNumberOfPeriodsIOS" to introductoryPriceNumberOfPeriodsIOS,
+        "introductoryPricePaymentModeIOS" to introductoryPricePaymentModeIOS?.toJson(),
+        "introductoryPriceSubscriptionPeriodIOS" to introductoryPriceSubscriptionPeriodIOS?.toJson(),
+        "isFamilyShareableIOS" to isFamilyShareableIOS,
+        "jsonRepresentationIOS" to jsonRepresentationIOS,
+        "platform" to platform.toJson(),
+        "price" to price,
+        "subscriptionInfoIOS" to subscriptionInfoIOS?.toJson(),
+        "subscriptionPeriodNumberIOS" to subscriptionPeriodNumberIOS,
+        "subscriptionPeriodUnitIOS" to subscriptionPeriodUnitIOS?.toJson(),
+        "title" to title,
+        "type" to type.toJson(),
+        "typeIOS" to typeIOS.toJson(),
+    )
+}
+
+public data class PurchaseAndroid(
+    val autoRenewingAndroid: Boolean? = null,
+    val dataAndroid: String? = null,
+    val developerPayloadAndroid: String? = null,
+    override val id: String,
+    override val ids: List<String>? = null,
+    val isAcknowledgedAndroid: Boolean? = null,
+    override val isAutoRenewing: Boolean,
+    val obfuscatedAccountIdAndroid: String? = null,
+    val obfuscatedProfileIdAndroid: String? = null,
+    val packageNameAndroid: String? = null,
+    override val platform: IapPlatform,
+    override val productId: String,
+    override val purchaseState: PurchaseState,
+    override val purchaseToken: String? = null,
+    override val quantity: Int,
+    val signatureAndroid: String? = null,
+    override val transactionDate: Double,
+    val transactionId: String? = null
+) : PurchaseCommon, Purchase {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PurchaseAndroid {
+            return PurchaseAndroid(
+                autoRenewingAndroid = json["autoRenewingAndroid"] as Boolean?,
+                dataAndroid = json["dataAndroid"] as String?,
+                developerPayloadAndroid = json["developerPayloadAndroid"] as String?,
+                id = json["id"] as String,
+                ids = (json["ids"] as List<*>?)?.map { it as String },
+                isAcknowledgedAndroid = json["isAcknowledgedAndroid"] as Boolean?,
+                isAutoRenewing = json["isAutoRenewing"] as Boolean,
+                obfuscatedAccountIdAndroid = json["obfuscatedAccountIdAndroid"] as String?,
+                obfuscatedProfileIdAndroid = json["obfuscatedProfileIdAndroid"] as String?,
+                packageNameAndroid = json["packageNameAndroid"] as String?,
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                productId = json["productId"] as String,
+                purchaseState = PurchaseState.fromJson(json["purchaseState"] as String),
+                purchaseToken = json["purchaseToken"] as String?,
+                quantity = (json["quantity"] as Number).toInt(),
+                signatureAndroid = json["signatureAndroid"] as String?,
+                transactionDate = (json["transactionDate"] as Number).toDouble(),
+                transactionId = json["transactionId"] as String?,
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "PurchaseAndroid",
+        "autoRenewingAndroid" to autoRenewingAndroid,
+        "dataAndroid" to dataAndroid,
+        "developerPayloadAndroid" to developerPayloadAndroid,
+        "id" to id,
+        "ids" to ids?.map { it },
+        "isAcknowledgedAndroid" to isAcknowledgedAndroid,
+        "isAutoRenewing" to isAutoRenewing,
+        "obfuscatedAccountIdAndroid" to obfuscatedAccountIdAndroid,
+        "obfuscatedProfileIdAndroid" to obfuscatedProfileIdAndroid,
+        "packageNameAndroid" to packageNameAndroid,
+        "platform" to platform.toJson(),
+        "productId" to productId,
+        "purchaseState" to purchaseState.toJson(),
+        "purchaseToken" to purchaseToken,
+        "quantity" to quantity,
+        "signatureAndroid" to signatureAndroid,
+        "transactionDate" to transactionDate,
+        "transactionId" to transactionId,
+    )
+}
+
+public data class PurchaseError(
+    val code: ErrorCode,
+    val message: String,
+    val productId: String? = null
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PurchaseError {
+            return PurchaseError(
+                code = ErrorCode.fromJson(json["code"] as String),
+                message = json["message"] as String,
+                productId = json["productId"] as String?,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "PurchaseError",
+        "code" to code.toJson(),
+        "message" to message,
+        "productId" to productId,
+    )
+}
+
+public data class PurchaseIOS(
+    val appAccountToken: String? = null,
+    val appBundleIdIOS: String? = null,
+    val countryCodeIOS: String? = null,
+    val currencyCodeIOS: String? = null,
+    val currencySymbolIOS: String? = null,
+    val environmentIOS: String? = null,
+    val expirationDateIOS: Double? = null,
+    override val id: String,
+    override val ids: List<String>? = null,
+    override val isAutoRenewing: Boolean,
+    val isUpgradedIOS: Boolean? = null,
+    val offerIOS: PurchaseOfferIOS? = null,
+    val originalTransactionDateIOS: Double? = null,
+    val originalTransactionIdentifierIOS: String? = null,
+    val ownershipTypeIOS: String? = null,
+    override val platform: IapPlatform,
+    override val productId: String,
+    override val purchaseState: PurchaseState,
+    override val purchaseToken: String? = null,
+    override val quantity: Int,
+    val quantityIOS: Int? = null,
+    val reasonIOS: String? = null,
+    val reasonStringRepresentationIOS: String? = null,
+    val revocationDateIOS: Double? = null,
+    val revocationReasonIOS: String? = null,
+    val storefrontCountryCodeIOS: String? = null,
+    val subscriptionGroupIdIOS: String? = null,
+    override val transactionDate: Double,
+    val transactionId: String,
+    val transactionReasonIOS: String? = null,
+    val webOrderLineItemIdIOS: String? = null
+) : PurchaseCommon, Purchase {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PurchaseIOS {
+            return PurchaseIOS(
+                appAccountToken = json["appAccountToken"] as String?,
+                appBundleIdIOS = json["appBundleIdIOS"] as String?,
+                countryCodeIOS = json["countryCodeIOS"] as String?,
+                currencyCodeIOS = json["currencyCodeIOS"] as String?,
+                currencySymbolIOS = json["currencySymbolIOS"] as String?,
+                environmentIOS = json["environmentIOS"] as String?,
+                expirationDateIOS = (json["expirationDateIOS"] as Number?)?.toDouble(),
+                id = json["id"] as String,
+                ids = (json["ids"] as List<*>?)?.map { it as String },
+                isAutoRenewing = json["isAutoRenewing"] as Boolean,
+                isUpgradedIOS = json["isUpgradedIOS"] as Boolean?,
+                offerIOS = (json["offerIOS"] as Map<String, Any?>?)?.let { PurchaseOfferIOS.fromJson(it) },
+                originalTransactionDateIOS = (json["originalTransactionDateIOS"] as Number?)?.toDouble(),
+                originalTransactionIdentifierIOS = json["originalTransactionIdentifierIOS"] as String?,
+                ownershipTypeIOS = json["ownershipTypeIOS"] as String?,
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                productId = json["productId"] as String,
+                purchaseState = PurchaseState.fromJson(json["purchaseState"] as String),
+                purchaseToken = json["purchaseToken"] as String?,
+                quantity = (json["quantity"] as Number).toInt(),
+                quantityIOS = (json["quantityIOS"] as Number?)?.toInt(),
+                reasonIOS = json["reasonIOS"] as String?,
+                reasonStringRepresentationIOS = json["reasonStringRepresentationIOS"] as String?,
+                revocationDateIOS = (json["revocationDateIOS"] as Number?)?.toDouble(),
+                revocationReasonIOS = json["revocationReasonIOS"] as String?,
+                storefrontCountryCodeIOS = json["storefrontCountryCodeIOS"] as String?,
+                subscriptionGroupIdIOS = json["subscriptionGroupIdIOS"] as String?,
+                transactionDate = (json["transactionDate"] as Number).toDouble(),
+                transactionId = json["transactionId"] as String,
+                transactionReasonIOS = json["transactionReasonIOS"] as String?,
+                webOrderLineItemIdIOS = json["webOrderLineItemIdIOS"] as String?,
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "PurchaseIOS",
+        "appAccountToken" to appAccountToken,
+        "appBundleIdIOS" to appBundleIdIOS,
+        "countryCodeIOS" to countryCodeIOS,
+        "currencyCodeIOS" to currencyCodeIOS,
+        "currencySymbolIOS" to currencySymbolIOS,
+        "environmentIOS" to environmentIOS,
+        "expirationDateIOS" to expirationDateIOS,
+        "id" to id,
+        "ids" to ids?.map { it },
+        "isAutoRenewing" to isAutoRenewing,
+        "isUpgradedIOS" to isUpgradedIOS,
+        "offerIOS" to offerIOS?.toJson(),
+        "originalTransactionDateIOS" to originalTransactionDateIOS,
+        "originalTransactionIdentifierIOS" to originalTransactionIdentifierIOS,
+        "ownershipTypeIOS" to ownershipTypeIOS,
+        "platform" to platform.toJson(),
+        "productId" to productId,
+        "purchaseState" to purchaseState.toJson(),
+        "purchaseToken" to purchaseToken,
+        "quantity" to quantity,
+        "quantityIOS" to quantityIOS,
+        "reasonIOS" to reasonIOS,
+        "reasonStringRepresentationIOS" to reasonStringRepresentationIOS,
+        "revocationDateIOS" to revocationDateIOS,
+        "revocationReasonIOS" to revocationReasonIOS,
+        "storefrontCountryCodeIOS" to storefrontCountryCodeIOS,
+        "subscriptionGroupIdIOS" to subscriptionGroupIdIOS,
+        "transactionDate" to transactionDate,
+        "transactionId" to transactionId,
+        "transactionReasonIOS" to transactionReasonIOS,
+        "webOrderLineItemIdIOS" to webOrderLineItemIdIOS,
+    )
+}
+
+public data class PurchaseOfferIOS(
+    val id: String,
+    val paymentMode: String,
+    val type: String
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PurchaseOfferIOS {
+            return PurchaseOfferIOS(
+                id = json["id"] as String,
+                paymentMode = json["paymentMode"] as String,
+                type = json["type"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "PurchaseOfferIOS",
+        "id" to id,
+        "paymentMode" to paymentMode,
+        "type" to type,
+    )
+}
+
+public data class ReceiptValidationResultAndroid(
+    val autoRenewing: Boolean,
+    val betaProduct: Boolean,
+    val cancelDate: Double? = null,
+    val cancelReason: String? = null,
+    val deferredDate: Double? = null,
+    val deferredSku: String? = null,
+    val freeTrialEndDate: Double,
+    val gracePeriodEndDate: Double,
+    val parentProductId: String,
+    val productId: String,
+    val productType: String,
+    val purchaseDate: Double,
+    val quantity: Int,
+    val receiptId: String,
+    val renewalDate: Double,
+    val term: String,
+    val termSku: String,
+    val testTransaction: Boolean
+) : ReceiptValidationResult {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ReceiptValidationResultAndroid {
+            return ReceiptValidationResultAndroid(
+                autoRenewing = json["autoRenewing"] as Boolean,
+                betaProduct = json["betaProduct"] as Boolean,
+                cancelDate = (json["cancelDate"] as Number?)?.toDouble(),
+                cancelReason = json["cancelReason"] as String?,
+                deferredDate = (json["deferredDate"] as Number?)?.toDouble(),
+                deferredSku = json["deferredSku"] as String?,
+                freeTrialEndDate = (json["freeTrialEndDate"] as Number).toDouble(),
+                gracePeriodEndDate = (json["gracePeriodEndDate"] as Number).toDouble(),
+                parentProductId = json["parentProductId"] as String,
+                productId = json["productId"] as String,
+                productType = json["productType"] as String,
+                purchaseDate = (json["purchaseDate"] as Number).toDouble(),
+                quantity = (json["quantity"] as Number).toInt(),
+                receiptId = json["receiptId"] as String,
+                renewalDate = (json["renewalDate"] as Number).toDouble(),
+                term = json["term"] as String,
+                termSku = json["termSku"] as String,
+                testTransaction = json["testTransaction"] as Boolean,
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ReceiptValidationResultAndroid",
+        "autoRenewing" to autoRenewing,
+        "betaProduct" to betaProduct,
+        "cancelDate" to cancelDate,
+        "cancelReason" to cancelReason,
+        "deferredDate" to deferredDate,
+        "deferredSku" to deferredSku,
+        "freeTrialEndDate" to freeTrialEndDate,
+        "gracePeriodEndDate" to gracePeriodEndDate,
+        "parentProductId" to parentProductId,
+        "productId" to productId,
+        "productType" to productType,
+        "purchaseDate" to purchaseDate,
+        "quantity" to quantity,
+        "receiptId" to receiptId,
+        "renewalDate" to renewalDate,
+        "term" to term,
+        "termSku" to termSku,
+        "testTransaction" to testTransaction,
+    )
+}
+
+public data class ReceiptValidationResultIOS(
+    /**
+     * Whether the receipt is valid
+     */
+    val isValid: Boolean,
+    /**
+     * JWS representation
+     */
+    val jwsRepresentation: String,
+    /**
+     * Latest transaction if available
+     */
+    val latestTransaction: Purchase? = null,
+    /**
+     * Receipt data string
+     */
+    val receiptData: String
+) : ReceiptValidationResult {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ReceiptValidationResultIOS {
+            return ReceiptValidationResultIOS(
+                isValid = json["isValid"] as Boolean,
+                jwsRepresentation = json["jwsRepresentation"] as String,
+                latestTransaction = (json["latestTransaction"] as Map<String, Any?>?)?.let { Purchase.fromJson(it) },
+                receiptData = json["receiptData"] as String,
+            )
+        }
+    }
+
+    override fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "ReceiptValidationResultIOS",
+        "isValid" to isValid,
+        "jwsRepresentation" to jwsRepresentation,
+        "latestTransaction" to latestTransaction?.toJson(),
+        "receiptData" to receiptData,
+    )
+}
+
+public data class RefundResultIOS(
+    val message: String? = null,
+    val status: String
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RefundResultIOS {
+            return RefundResultIOS(
+                message = json["message"] as String?,
+                status = json["status"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "RefundResultIOS",
+        "message" to message,
+        "status" to status,
+    )
+}
+
+public data class RenewalInfoIOS(
+    val autoRenewPreference: String? = null,
+    val jsonRepresentation: String? = null,
+    val willAutoRenew: Boolean
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RenewalInfoIOS {
+            return RenewalInfoIOS(
+                autoRenewPreference = json["autoRenewPreference"] as String?,
+                jsonRepresentation = json["jsonRepresentation"] as String?,
+                willAutoRenew = json["willAutoRenew"] as Boolean,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "RenewalInfoIOS",
+        "autoRenewPreference" to autoRenewPreference,
+        "jsonRepresentation" to jsonRepresentation,
+        "willAutoRenew" to willAutoRenew,
+    )
+}
+
+public sealed interface RequestPurchaseResult
+
+public data class RequestPurchaseResultPurchase(val value: Purchase?) : RequestPurchaseResult
+
+public data class RequestPurchaseResultPurchases(val value: List<Purchase>?) : RequestPurchaseResult
+
+public data class SubscriptionInfoIOS(
+    val introductoryOffer: SubscriptionOfferIOS? = null,
+    val promotionalOffers: List<SubscriptionOfferIOS>? = null,
+    val subscriptionGroupId: String,
+    val subscriptionPeriod: SubscriptionPeriodValueIOS
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): SubscriptionInfoIOS {
+            return SubscriptionInfoIOS(
+                introductoryOffer = (json["introductoryOffer"] as Map<String, Any?>?)?.let { SubscriptionOfferIOS.fromJson(it) },
+                promotionalOffers = (json["promotionalOffers"] as List<*>?)?.map { SubscriptionOfferIOS.fromJson((it as Map<String, Any?>)) },
+                subscriptionGroupId = json["subscriptionGroupId"] as String,
+                subscriptionPeriod = SubscriptionPeriodValueIOS.fromJson((json["subscriptionPeriod"] as Map<String, Any?>)),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "SubscriptionInfoIOS",
+        "introductoryOffer" to introductoryOffer?.toJson(),
+        "promotionalOffers" to promotionalOffers?.map { it.toJson() },
+        "subscriptionGroupId" to subscriptionGroupId,
+        "subscriptionPeriod" to subscriptionPeriod.toJson(),
+    )
+}
+
+public data class SubscriptionOfferIOS(
+    val displayPrice: String,
+    val id: String,
+    val paymentMode: PaymentModeIOS,
+    val period: SubscriptionPeriodValueIOS,
+    val periodCount: Int,
+    val price: Double,
+    val type: SubscriptionOfferTypeIOS
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): SubscriptionOfferIOS {
+            return SubscriptionOfferIOS(
+                displayPrice = json["displayPrice"] as String,
+                id = json["id"] as String,
+                paymentMode = PaymentModeIOS.fromJson(json["paymentMode"] as String),
+                period = SubscriptionPeriodValueIOS.fromJson((json["period"] as Map<String, Any?>)),
+                periodCount = (json["periodCount"] as Number).toInt(),
+                price = (json["price"] as Number).toDouble(),
+                type = SubscriptionOfferTypeIOS.fromJson(json["type"] as String),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "SubscriptionOfferIOS",
+        "displayPrice" to displayPrice,
+        "id" to id,
+        "paymentMode" to paymentMode.toJson(),
+        "period" to period.toJson(),
+        "periodCount" to periodCount,
+        "price" to price,
+        "type" to type.toJson(),
+    )
+}
+
+public data class SubscriptionPeriodValueIOS(
+    val unit: SubscriptionPeriodIOS,
+    val value: Int
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): SubscriptionPeriodValueIOS {
+            return SubscriptionPeriodValueIOS(
+                unit = SubscriptionPeriodIOS.fromJson(json["unit"] as String),
+                value = (json["value"] as Number).toInt(),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "SubscriptionPeriodValueIOS",
+        "unit" to unit.toJson(),
+        "value" to value,
+    )
+}
+
+public data class SubscriptionStatusIOS(
+    val renewalInfo: RenewalInfoIOS? = null,
+    val state: String
+) {
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): SubscriptionStatusIOS {
+            return SubscriptionStatusIOS(
+                renewalInfo = (json["renewalInfo"] as Map<String, Any?>?)?.let { RenewalInfoIOS.fromJson(it) },
+                state = json["state"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "__typename" to "SubscriptionStatusIOS",
+        "renewalInfo" to renewalInfo?.toJson(),
+        "state" to state,
+    )
+}
+
+public typealias VoidResult = Unit
+
+// MARK: - Input Objects
+
+public data class AndroidSubscriptionOfferInput(
+    /**
+     * Offer token
+     */
+    val offerToken: String,
+    /**
+     * Product SKU
+     */
+    val sku: String
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): AndroidSubscriptionOfferInput {
+            return AndroidSubscriptionOfferInput(
+                offerToken = json["offerToken"] as String,
+                sku = json["sku"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "offerToken" to offerToken,
+        "sku" to sku,
+    )
+}
+
+public data class DeepLinkOptions(
+    /**
+     * Android package name to target (required on Android)
+     */
+    val packageNameAndroid: String? = null,
+    /**
+     * Android SKU to open (required on Android)
+     */
+    val skuAndroid: String? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): DeepLinkOptions {
+            return DeepLinkOptions(
+                packageNameAndroid = json["packageNameAndroid"] as String?,
+                skuAndroid = json["skuAndroid"] as String?,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "packageNameAndroid" to packageNameAndroid,
+        "skuAndroid" to skuAndroid,
+    )
+}
+
+public data class DiscountOfferInputIOS(
+    /**
+     * Discount identifier
+     */
+    val identifier: String,
+    /**
+     * Key identifier for validation
+     */
+    val keyIdentifier: String,
+    /**
+     * Cryptographic nonce
+     */
+    val nonce: String,
+    /**
+     * Signature for validation
+     */
+    val signature: String,
+    /**
+     * Timestamp of discount offer
+     */
+    val timestamp: Double
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): DiscountOfferInputIOS {
+            return DiscountOfferInputIOS(
+                identifier = json["identifier"] as String,
+                keyIdentifier = json["keyIdentifier"] as String,
+                nonce = json["nonce"] as String,
+                signature = json["signature"] as String,
+                timestamp = (json["timestamp"] as Number).toDouble(),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "identifier" to identifier,
+        "keyIdentifier" to keyIdentifier,
+        "nonce" to nonce,
+        "signature" to signature,
+        "timestamp" to timestamp,
+    )
+}
+
+public data class ProductRequest(
+    val skus: List<String>,
+    val type: ProductQueryType? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductRequest {
+            return ProductRequest(
+                skus = (json["skus"] as List<*>).map { it as String },
+                type = (json["type"] as String?)?.let { ProductQueryType.fromJson(it) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "skus" to skus.map { it },
+        "type" to type?.toJson(),
+    )
+}
+
+public data class PurchaseInput(
+    val id: String,
+    val ids: List<String>? = null,
+    val isAutoRenewing: Boolean,
+    val platform: IapPlatform,
+    val productId: String,
+    val purchaseState: PurchaseState,
+    val purchaseToken: String? = null,
+    val quantity: Int,
+    val transactionDate: Double
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PurchaseInput {
+            return PurchaseInput(
+                id = json["id"] as String,
+                ids = (json["ids"] as List<*>?)?.map { it as String },
+                isAutoRenewing = json["isAutoRenewing"] as Boolean,
+                platform = IapPlatform.fromJson(json["platform"] as String),
+                productId = json["productId"] as String,
+                purchaseState = PurchaseState.fromJson(json["purchaseState"] as String),
+                purchaseToken = json["purchaseToken"] as String?,
+                quantity = (json["quantity"] as Number).toInt(),
+                transactionDate = (json["transactionDate"] as Number).toDouble(),
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "id" to id,
+        "ids" to ids?.map { it },
+        "isAutoRenewing" to isAutoRenewing,
+        "platform" to platform.toJson(),
+        "productId" to productId,
+        "purchaseState" to purchaseState.toJson(),
+        "purchaseToken" to purchaseToken,
+        "quantity" to quantity,
+        "transactionDate" to transactionDate,
+    )
+}
+
+public data class PurchaseOptions(
+    /**
+     * Also emit results through the iOS event listeners
+     */
+    val alsoPublishToEventListenerIOS: Boolean? = null,
+    /**
+     * Limit to currently active items on iOS
+     */
+    val onlyIncludeActiveItemsIOS: Boolean? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): PurchaseOptions {
+            return PurchaseOptions(
+                alsoPublishToEventListenerIOS = json["alsoPublishToEventListenerIOS"] as Boolean?,
+                onlyIncludeActiveItemsIOS = json["onlyIncludeActiveItemsIOS"] as Boolean?,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "alsoPublishToEventListenerIOS" to alsoPublishToEventListenerIOS,
+        "onlyIncludeActiveItemsIOS" to onlyIncludeActiveItemsIOS,
+    )
+}
+
+public data class ReceiptValidationAndroidOptions(
+    val accessToken: String,
+    val isSub: Boolean? = null,
+    val packageName: String,
+    val productToken: String
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ReceiptValidationAndroidOptions {
+            return ReceiptValidationAndroidOptions(
+                accessToken = json["accessToken"] as String,
+                isSub = json["isSub"] as Boolean?,
+                packageName = json["packageName"] as String,
+                productToken = json["productToken"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "accessToken" to accessToken,
+        "isSub" to isSub,
+        "packageName" to packageName,
+        "productToken" to productToken,
+    )
+}
+
+public data class ReceiptValidationProps(
+    /**
+     * Android-specific validation options
+     */
+    val androidOptions: ReceiptValidationAndroidOptions? = null,
+    /**
+     * Product SKU to validate
+     */
+    val sku: String
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ReceiptValidationProps {
+            return ReceiptValidationProps(
+                androidOptions = (json["androidOptions"] as Map<String, Any?>?)?.let { ReceiptValidationAndroidOptions.fromJson(it) },
+                sku = json["sku"] as String,
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "androidOptions" to androidOptions?.toJson(),
+        "sku" to sku,
+    )
+}
+
+public data class RequestPurchaseAndroidProps(
+    /**
+     * Personalized offer flag
+     */
+    val isOfferPersonalized: Boolean? = null,
+    /**
+     * Obfuscated account ID
+     */
+    val obfuscatedAccountIdAndroid: String? = null,
+    /**
+     * Obfuscated profile ID
+     */
+    val obfuscatedProfileIdAndroid: String? = null,
+    /**
+     * List of product SKUs
+     */
+    val skus: List<String>
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestPurchaseAndroidProps {
+            return RequestPurchaseAndroidProps(
+                isOfferPersonalized = json["isOfferPersonalized"] as Boolean?,
+                obfuscatedAccountIdAndroid = json["obfuscatedAccountIdAndroid"] as String?,
+                obfuscatedProfileIdAndroid = json["obfuscatedProfileIdAndroid"] as String?,
+                skus = (json["skus"] as List<*>).map { it as String },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "isOfferPersonalized" to isOfferPersonalized,
+        "obfuscatedAccountIdAndroid" to obfuscatedAccountIdAndroid,
+        "obfuscatedProfileIdAndroid" to obfuscatedProfileIdAndroid,
+        "skus" to skus.map { it },
+    )
+}
+
+public data class RequestPurchaseIosProps(
+    /**
+     * Auto-finish transaction (dangerous)
+     */
+    val andDangerouslyFinishTransactionAutomatically: Boolean? = null,
+    /**
+     * App account token for user tracking
+     */
+    val appAccountToken: String? = null,
+    /**
+     * Purchase quantity
+     */
+    val quantity: Int? = null,
+    /**
+     * Product SKU
+     */
+    val sku: String,
+    /**
+     * Discount offer to apply
+     */
+    val withOffer: DiscountOfferInputIOS? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestPurchaseIosProps {
+            return RequestPurchaseIosProps(
+                andDangerouslyFinishTransactionAutomatically = json["andDangerouslyFinishTransactionAutomatically"] as Boolean?,
+                appAccountToken = json["appAccountToken"] as String?,
+                quantity = (json["quantity"] as Number?)?.toInt(),
+                sku = json["sku"] as String,
+                withOffer = (json["withOffer"] as Map<String, Any?>?)?.let { DiscountOfferInputIOS.fromJson(it) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "andDangerouslyFinishTransactionAutomatically" to andDangerouslyFinishTransactionAutomatically,
+        "appAccountToken" to appAccountToken,
+        "quantity" to quantity,
+        "sku" to sku,
+        "withOffer" to withOffer?.toJson(),
+    )
+}
+
+public data class RequestPurchaseProps(
+    val request: Request,
+    val type: ProductQueryType
+) {
+    init {
+        when (request) {
+            is Request.Purchase -> require(type == ProductQueryType.InApp) { "type must be IN_APP when request is purchase" }
+            is Request.Subscription -> require(type == ProductQueryType.Subs) { "type must be SUBS when request is subscription" }
+        }
+    }
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestPurchaseProps {
+            val rawType = (json["type"] as String?)?.let { ProductQueryType.fromJson(it) }
+            val purchaseJson = json["requestPurchase"] as Map<String, Any?>?
+            if (purchaseJson != null) {
+                val request = Request.Purchase(RequestPurchasePropsByPlatforms.fromJson(purchaseJson))
+                val finalType = rawType ?: ProductQueryType.InApp
+                require(finalType == ProductQueryType.InApp) { "type must be IN_APP when requestPurchase is provided" }
+                return RequestPurchaseProps(request = request, type = finalType)
+            }
+            val subscriptionJson = json["requestSubscription"] as Map<String, Any?>?
+            if (subscriptionJson != null) {
+                val request = Request.Subscription(RequestSubscriptionPropsByPlatforms.fromJson(subscriptionJson))
+                val finalType = rawType ?: ProductQueryType.Subs
+                require(finalType == ProductQueryType.Subs) { "type must be SUBS when requestSubscription is provided" }
+                return RequestPurchaseProps(request = request, type = finalType)
+            }
+            throw IllegalArgumentException("RequestPurchaseProps requires requestPurchase or requestSubscription")
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = when (request) {
+        is Request.Purchase -> mapOf(
+            "requestPurchase" to request.value.toJson(),
+            "type" to type.toJson(),
+        )
+        is Request.Subscription -> mapOf(
+            "requestSubscription" to request.value.toJson(),
+            "type" to type.toJson(),
+        )
+    }
+
+    sealed class Request {
+        data class Purchase(val value: RequestPurchasePropsByPlatforms) : Request()
+        data class Subscription(val value: RequestSubscriptionPropsByPlatforms) : Request()
+    }
+}
+
+public data class RequestPurchasePropsByPlatforms(
+    /**
+     * Android-specific purchase parameters
+     */
+    val android: RequestPurchaseAndroidProps? = null,
+    /**
+     * iOS-specific purchase parameters
+     */
+    val ios: RequestPurchaseIosProps? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestPurchasePropsByPlatforms {
+            return RequestPurchasePropsByPlatforms(
+                android = (json["android"] as Map<String, Any?>?)?.let { RequestPurchaseAndroidProps.fromJson(it) },
+                ios = (json["ios"] as Map<String, Any?>?)?.let { RequestPurchaseIosProps.fromJson(it) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "android" to android?.toJson(),
+        "ios" to ios?.toJson(),
+    )
+}
+
+public data class RequestSubscriptionAndroidProps(
+    /**
+     * Personalized offer flag
+     */
+    val isOfferPersonalized: Boolean? = null,
+    /**
+     * Obfuscated account ID
+     */
+    val obfuscatedAccountIdAndroid: String? = null,
+    /**
+     * Obfuscated profile ID
+     */
+    val obfuscatedProfileIdAndroid: String? = null,
+    /**
+     * Purchase token for upgrades/downgrades
+     */
+    val purchaseTokenAndroid: String? = null,
+    /**
+     * Replacement mode for subscription changes
+     */
+    val replacementModeAndroid: Int? = null,
+    /**
+     * List of subscription SKUs
+     */
+    val skus: List<String>,
+    /**
+     * Subscription offers
+     */
+    val subscriptionOffers: List<AndroidSubscriptionOfferInput>? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestSubscriptionAndroidProps {
+            return RequestSubscriptionAndroidProps(
+                isOfferPersonalized = json["isOfferPersonalized"] as Boolean?,
+                obfuscatedAccountIdAndroid = json["obfuscatedAccountIdAndroid"] as String?,
+                obfuscatedProfileIdAndroid = json["obfuscatedProfileIdAndroid"] as String?,
+                purchaseTokenAndroid = json["purchaseTokenAndroid"] as String?,
+                replacementModeAndroid = (json["replacementModeAndroid"] as Number?)?.toInt(),
+                skus = (json["skus"] as List<*>).map { it as String },
+                subscriptionOffers = (json["subscriptionOffers"] as List<*>?)?.map { AndroidSubscriptionOfferInput.fromJson((it as Map<String, Any?>)) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "isOfferPersonalized" to isOfferPersonalized,
+        "obfuscatedAccountIdAndroid" to obfuscatedAccountIdAndroid,
+        "obfuscatedProfileIdAndroid" to obfuscatedProfileIdAndroid,
+        "purchaseTokenAndroid" to purchaseTokenAndroid,
+        "replacementModeAndroid" to replacementModeAndroid,
+        "skus" to skus.map { it },
+        "subscriptionOffers" to subscriptionOffers?.map { it.toJson() },
+    )
+}
+
+public data class RequestSubscriptionIosProps(
+    val andDangerouslyFinishTransactionAutomatically: Boolean? = null,
+    val appAccountToken: String? = null,
+    val quantity: Int? = null,
+    val sku: String,
+    val withOffer: DiscountOfferInputIOS? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestSubscriptionIosProps {
+            return RequestSubscriptionIosProps(
+                andDangerouslyFinishTransactionAutomatically = json["andDangerouslyFinishTransactionAutomatically"] as Boolean?,
+                appAccountToken = json["appAccountToken"] as String?,
+                quantity = (json["quantity"] as Number?)?.toInt(),
+                sku = json["sku"] as String,
+                withOffer = (json["withOffer"] as Map<String, Any?>?)?.let { DiscountOfferInputIOS.fromJson(it) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "andDangerouslyFinishTransactionAutomatically" to andDangerouslyFinishTransactionAutomatically,
+        "appAccountToken" to appAccountToken,
+        "quantity" to quantity,
+        "sku" to sku,
+        "withOffer" to withOffer?.toJson(),
+    )
+}
+
+public data class RequestSubscriptionPropsByPlatforms(
+    /**
+     * Android-specific subscription parameters
+     */
+    val android: RequestSubscriptionAndroidProps? = null,
+    /**
+     * iOS-specific subscription parameters
+     */
+    val ios: RequestSubscriptionIosProps? = null
+) {
+    companion object {
+        fun fromJson(json: Map<String, Any?>): RequestSubscriptionPropsByPlatforms {
+            return RequestSubscriptionPropsByPlatforms(
+                android = (json["android"] as Map<String, Any?>?)?.let { RequestSubscriptionAndroidProps.fromJson(it) },
+                ios = (json["ios"] as Map<String, Any?>?)?.let { RequestSubscriptionIosProps.fromJson(it) },
+            )
+        }
+    }
+
+    fun toJson(): Map<String, Any?> = mapOf(
+        "android" to android?.toJson(),
+        "ios" to ios?.toJson(),
+    )
+}
+
+// MARK: - Unions
+
+public sealed interface Product : ProductCommon {
+    fun toJson(): Map<String, Any?>
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): Product {
+            return when (json["__typename"] as String?) {
+                "ProductAndroid" -> ProductAndroid.fromJson(json)
+                "ProductIOS" -> ProductIOS.fromJson(json)
+                else -> throw IllegalArgumentException("Unknown __typename for Product: ${json["__typename"]}")
+            }
+        }
+    }
+}
+
+public sealed interface ProductSubscription : ProductCommon {
+    fun toJson(): Map<String, Any?>
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ProductSubscription {
+            return when (json["__typename"] as String?) {
+                "ProductSubscriptionAndroid" -> ProductSubscriptionAndroid.fromJson(json)
+                "ProductSubscriptionIOS" -> ProductSubscriptionIOS.fromJson(json)
+                else -> throw IllegalArgumentException("Unknown __typename for ProductSubscription: ${json["__typename"]}")
+            }
+        }
+    }
+}
+
+public sealed interface Purchase : PurchaseCommon {
+    fun toJson(): Map<String, Any?>
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): Purchase {
+            return when (json["__typename"] as String?) {
+                "PurchaseAndroid" -> PurchaseAndroid.fromJson(json)
+                "PurchaseIOS" -> PurchaseIOS.fromJson(json)
+                else -> throw IllegalArgumentException("Unknown __typename for Purchase: ${json["__typename"]}")
+            }
+        }
+    }
+}
+
+public sealed interface ReceiptValidationResult {
+    fun toJson(): Map<String, Any?>
+
+    companion object {
+        fun fromJson(json: Map<String, Any?>): ReceiptValidationResult {
+            return when (json["__typename"] as String?) {
+                "ReceiptValidationResultAndroid" -> ReceiptValidationResultAndroid.fromJson(json)
+                "ReceiptValidationResultIOS" -> ReceiptValidationResultIOS.fromJson(json)
+                else -> throw IllegalArgumentException("Unknown __typename for ReceiptValidationResult: ${json["__typename"]}")
+            }
+        }
+    }
+}
+
+// MARK: - Root Operations
+
+/**
+ * GraphQL root mutation operations.
+ */
+public interface MutationResolver {
+    /**
+     * Acknowledge a non-consumable purchase or subscription
+     */
+    suspend fun acknowledgePurchaseAndroid(purchaseToken: String): Boolean
+    /**
+     * Initiate a refund request for a product (iOS 15+)
+     */
+    suspend fun beginRefundRequestIOS(sku: String): String?
+    /**
+     * Clear pending transactions from the StoreKit payment queue
+     */
+    suspend fun clearTransactionIOS(): Boolean
+    /**
+     * Consume a purchase token so it can be repurchased
+     */
+    suspend fun consumePurchaseAndroid(purchaseToken: String): Boolean
+    /**
+     * Open the native subscription management surface
+     */
+    suspend fun deepLinkToSubscriptions(options: DeepLinkOptions? = null): Unit
+    /**
+     * Close the platform billing connection
+     */
+    suspend fun endConnection(): Boolean
+    /**
+     * Finish a transaction after validating receipts
+     */
+    suspend fun finishTransaction(purchase: PurchaseInput, isConsumable: Boolean? = null): Unit
+    /**
+     * Establish the platform billing connection
+     */
+    suspend fun initConnection(): Boolean
+    /**
+     * Present the App Store code redemption sheet
+     */
+    suspend fun presentCodeRedemptionSheetIOS(): Boolean
+    /**
+     * Initiate a purchase flow; rely on events for final state
+     */
+    suspend fun requestPurchase(params: RequestPurchaseProps): RequestPurchaseResult?
+    /**
+     * Purchase the promoted product surfaced by the App Store
+     */
+    suspend fun requestPurchaseOnPromotedProductIOS(): Boolean
+    /**
+     * Restore completed purchases across platforms
+     */
+    suspend fun restorePurchases(): Unit
+    /**
+     * Open subscription management UI and return changed purchases (iOS 15+)
+     */
+    suspend fun showManageSubscriptionsIOS(): List<PurchaseIOS>
+    /**
+     * Force a StoreKit sync for transactions (iOS 15+)
+     */
+    suspend fun syncIOS(): Boolean
+    /**
+     * Validate purchase receipts with the configured providers
+     */
+    suspend fun validateReceipt(options: ReceiptValidationProps): ReceiptValidationResult
+}
+
+/**
+ * GraphQL root query operations.
+ */
+public interface QueryResolver {
+    /**
+     * Get current StoreKit 2 entitlements (iOS 15+)
+     */
+    suspend fun currentEntitlementIOS(sku: String): PurchaseIOS?
+    /**
+     * Retrieve products or subscriptions from the store
+     */
+    suspend fun fetchProducts(params: ProductRequest): FetchProductsResult
+    /**
+     * Get active subscriptions (filters by subscriptionIds when provided)
+     */
+    suspend fun getActiveSubscriptions(subscriptionIds: List<String>? = null): List<ActiveSubscription>
+    /**
+     * Fetch the current app transaction (iOS 16+)
+     */
+    suspend fun getAppTransactionIOS(): AppTransaction?
+    /**
+     * Get all available purchases for the current user
+     */
+    suspend fun getAvailablePurchases(options: PurchaseOptions? = null): List<Purchase>
+    /**
+     * Retrieve all pending transactions in the StoreKit queue
+     */
+    suspend fun getPendingTransactionsIOS(): List<PurchaseIOS>
+    /**
+     * Get the currently promoted product (iOS 11+)
+     */
+    suspend fun getPromotedProductIOS(): ProductIOS?
+    /**
+     * Get base64-encoded receipt data for validation
+     */
+    suspend fun getReceiptDataIOS(): String?
+    /**
+     * Get the current App Store storefront country code
+     */
+    suspend fun getStorefrontIOS(): String
+    /**
+     * Get the transaction JWS (StoreKit 2)
+     */
+    suspend fun getTransactionJwsIOS(sku: String): String?
+    /**
+     * Check whether the user has active subscriptions
+     */
+    suspend fun hasActiveSubscriptions(subscriptionIds: List<String>? = null): Boolean
+    /**
+     * Check introductory offer eligibility for a subscription group
+     */
+    suspend fun isEligibleForIntroOfferIOS(groupID: String): Boolean
+    /**
+     * Verify a StoreKit 2 transaction signature
+     */
+    suspend fun isTransactionVerifiedIOS(sku: String): Boolean
+    /**
+     * Get the latest transaction for a product using StoreKit 2
+     */
+    suspend fun latestTransactionIOS(sku: String): PurchaseIOS?
+    /**
+     * Get StoreKit 2 subscription status details (iOS 15+)
+     */
+    suspend fun subscriptionStatusIOS(sku: String): List<SubscriptionStatusIOS>
+    /**
+     * Validate a receipt for a specific product
+     */
+    suspend fun validateReceiptIOS(options: ReceiptValidationProps): ReceiptValidationResultIOS
+}
+
+/**
+ * GraphQL root subscription operations.
+ */
+public interface SubscriptionResolver {
+    /**
+     * Fires when the App Store surfaces a promoted product (iOS only)
+     */
+    suspend fun promotedProductIOS(): String
+    /**
+     * Fires when a purchase fails or is cancelled
+     */
+    suspend fun purchaseError(): PurchaseError
+    /**
+     * Fires when a purchase completes successfully or a pending purchase resolves
+     */
+    suspend fun purchaseUpdated(): Purchase
+}
+
+// MARK: - Root Operation Helpers
+
+// MARK: - Mutation Helpers
+
+public typealias MutationAcknowledgePurchaseAndroidHandler = suspend (purchaseToken: String) -> Boolean
+public typealias MutationBeginRefundRequestIOSHandler = suspend (sku: String) -> String?
+public typealias MutationClearTransactionIOSHandler = suspend () -> Boolean
+public typealias MutationConsumePurchaseAndroidHandler = suspend (purchaseToken: String) -> Boolean
+public typealias MutationDeepLinkToSubscriptionsHandler = suspend (options: DeepLinkOptions?) -> Unit
+public typealias MutationEndConnectionHandler = suspend () -> Boolean
+public typealias MutationFinishTransactionHandler = suspend (purchase: PurchaseInput, isConsumable: Boolean?) -> Unit
+public typealias MutationInitConnectionHandler = suspend () -> Boolean
+public typealias MutationPresentCodeRedemptionSheetIOSHandler = suspend () -> Boolean
+public typealias MutationRequestPurchaseHandler = suspend (params: RequestPurchaseProps) -> RequestPurchaseResult?
+public typealias MutationRequestPurchaseOnPromotedProductIOSHandler = suspend () -> Boolean
+public typealias MutationRestorePurchasesHandler = suspend () -> Unit
+public typealias MutationShowManageSubscriptionsIOSHandler = suspend () -> List<PurchaseIOS>
+public typealias MutationSyncIOSHandler = suspend () -> Boolean
+public typealias MutationValidateReceiptHandler = suspend (options: ReceiptValidationProps) -> ReceiptValidationResult
+
+public data class MutationHandlers(
+    val acknowledgePurchaseAndroid: MutationAcknowledgePurchaseAndroidHandler? = null,
+    val beginRefundRequestIOS: MutationBeginRefundRequestIOSHandler? = null,
+    val clearTransactionIOS: MutationClearTransactionIOSHandler? = null,
+    val consumePurchaseAndroid: MutationConsumePurchaseAndroidHandler? = null,
+    val deepLinkToSubscriptions: MutationDeepLinkToSubscriptionsHandler? = null,
+    val endConnection: MutationEndConnectionHandler? = null,
+    val finishTransaction: MutationFinishTransactionHandler? = null,
+    val initConnection: MutationInitConnectionHandler? = null,
+    val presentCodeRedemptionSheetIOS: MutationPresentCodeRedemptionSheetIOSHandler? = null,
+    val requestPurchase: MutationRequestPurchaseHandler? = null,
+    val requestPurchaseOnPromotedProductIOS: MutationRequestPurchaseOnPromotedProductIOSHandler? = null,
+    val restorePurchases: MutationRestorePurchasesHandler? = null,
+    val showManageSubscriptionsIOS: MutationShowManageSubscriptionsIOSHandler? = null,
+    val syncIOS: MutationSyncIOSHandler? = null,
+    val validateReceipt: MutationValidateReceiptHandler? = null
+)
+
+// MARK: - Query Helpers
+
+public typealias QueryCurrentEntitlementIOSHandler = suspend (sku: String) -> PurchaseIOS?
+public typealias QueryFetchProductsHandler = suspend (params: ProductRequest) -> FetchProductsResult
+public typealias QueryGetActiveSubscriptionsHandler = suspend (subscriptionIds: List<String>?) -> List<ActiveSubscription>
+public typealias QueryGetAppTransactionIOSHandler = suspend () -> AppTransaction?
+public typealias QueryGetAvailablePurchasesHandler = suspend (options: PurchaseOptions?) -> List<Purchase>
+public typealias QueryGetPendingTransactionsIOSHandler = suspend () -> List<PurchaseIOS>
+public typealias QueryGetPromotedProductIOSHandler = suspend () -> ProductIOS?
+public typealias QueryGetReceiptDataIOSHandler = suspend () -> String?
+public typealias QueryGetStorefrontIOSHandler = suspend () -> String
+public typealias QueryGetTransactionJwsIOSHandler = suspend (sku: String) -> String?
+public typealias QueryHasActiveSubscriptionsHandler = suspend (subscriptionIds: List<String>?) -> Boolean
+public typealias QueryIsEligibleForIntroOfferIOSHandler = suspend (groupID: String) -> Boolean
+public typealias QueryIsTransactionVerifiedIOSHandler = suspend (sku: String) -> Boolean
+public typealias QueryLatestTransactionIOSHandler = suspend (sku: String) -> PurchaseIOS?
+public typealias QuerySubscriptionStatusIOSHandler = suspend (sku: String) -> List<SubscriptionStatusIOS>
+public typealias QueryValidateReceiptIOSHandler = suspend (options: ReceiptValidationProps) -> ReceiptValidationResultIOS
+
+public data class QueryHandlers(
+    val currentEntitlementIOS: QueryCurrentEntitlementIOSHandler? = null,
+    val fetchProducts: QueryFetchProductsHandler? = null,
+    val getActiveSubscriptions: QueryGetActiveSubscriptionsHandler? = null,
+    val getAppTransactionIOS: QueryGetAppTransactionIOSHandler? = null,
+    val getAvailablePurchases: QueryGetAvailablePurchasesHandler? = null,
+    val getPendingTransactionsIOS: QueryGetPendingTransactionsIOSHandler? = null,
+    val getPromotedProductIOS: QueryGetPromotedProductIOSHandler? = null,
+    val getReceiptDataIOS: QueryGetReceiptDataIOSHandler? = null,
+    val getStorefrontIOS: QueryGetStorefrontIOSHandler? = null,
+    val getTransactionJwsIOS: QueryGetTransactionJwsIOSHandler? = null,
+    val hasActiveSubscriptions: QueryHasActiveSubscriptionsHandler? = null,
+    val isEligibleForIntroOfferIOS: QueryIsEligibleForIntroOfferIOSHandler? = null,
+    val isTransactionVerifiedIOS: QueryIsTransactionVerifiedIOSHandler? = null,
+    val latestTransactionIOS: QueryLatestTransactionIOSHandler? = null,
+    val subscriptionStatusIOS: QuerySubscriptionStatusIOSHandler? = null,
+    val validateReceiptIOS: QueryValidateReceiptIOSHandler? = null
+)
+
+// MARK: - Subscription Helpers
+
+public typealias SubscriptionPromotedProductIOSHandler = suspend () -> String
+public typealias SubscriptionPurchaseErrorHandler = suspend () -> PurchaseError
+public typealias SubscriptionPurchaseUpdatedHandler = suspend () -> Purchase
+
+public data class SubscriptionHandlers(
+    val promotedProductIOS: SubscriptionPromotedProductIOSHandler? = null,
+    val purchaseError: SubscriptionPurchaseErrorHandler? = null,
+    val purchaseUpdated: SubscriptionPurchaseUpdatedHandler? = null
+)

--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-1.0.7}"
+REPO="https://github.com/hyodotdev/openiap-gql"
+ASSET="openiap-kotlin.zip"
+DOWNLOAD_URL="${REPO}/releases/download/${VERSION}/${ASSET}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_DIR="${REPO_ROOT}/openiap/src/main/java/dev/hyo/openiap"
+TARGET_FILE="${TARGET_DIR}/Types.kt"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+printf 'Downloading %s\n' "${DOWNLOAD_URL}"
+curl -fL "${DOWNLOAD_URL}" -o "${TMP_DIR}/${ASSET}"
+
+printf 'Extracting Types.kt\n'
+unzip -q "${TMP_DIR}/${ASSET}" -d "${TMP_DIR}"
+
+mkdir -p "${TARGET_DIR}"
+rm -f "${TARGET_FILE}"
+cp "${TMP_DIR}/Types.kt" "${TARGET_FILE}"
+
+# Patch known Kotlin formatting issues in the upstream artifact so the file compiles
+TARGET_FILE="${TARGET_FILE}" python3 <<'PY'
+from pathlib import Path
+import os
+import re
+
+target = Path(os.environ["TARGET_FILE"])
+text = target.read_text()
+
+lines = text.splitlines()
+
+def first_index(predicate):
+    for idx, line in enumerate(lines):
+        if predicate(line):
+            return idx
+    return None
+
+
+package_idx = first_index(lambda line: line.startswith('package '))
+
+annotation_indices = [idx for idx, line in enumerate(lines) if line.startswith('@file:')]
+
+if package_idx is None:
+    insert_idx = annotation_indices[0] + 1 if annotation_indices else 0
+    lines.insert(insert_idx, 'package dev.hyo.openiap')
+    package_idx = insert_idx
+else:
+    lines[package_idx] = 'package dev.hyo.openiap'
+
+if annotation_indices and annotation_indices[0] > package_idx:
+    annotation_block = [lines[idx] for idx in annotation_indices]
+    for idx in reversed(annotation_indices):
+        lines.pop(idx)
+    package_idx = first_index(lambda line: line.startswith('package '))
+    for offset, line in enumerate(annotation_block):
+        lines.insert(package_idx + offset, line)
+    package_idx += len(annotation_block)
+
+# Ensure there is exactly one blank line between annotations and the package declaration
+package_idx = first_index(lambda line: line.startswith('package '))
+if package_idx is not None:
+    before_idx = package_idx - 1
+    if before_idx >= 0 and lines[before_idx].strip():
+        lines.insert(package_idx, '')
+        package_idx += 1
+    after_idx = package_idx + 1
+    if after_idx >= len(lines) or lines[after_idx].strip():
+        lines.insert(package_idx + 1, '')
+
+text = '\n'.join(lines)
+
+# Kotlin enums that declare a companion object require a trailing semicolon
+enum_pattern = re.compile(r"(\n\s*\w+\([^)]*\))\n\n(\s+companion object)")
+text = enum_pattern.sub(lambda m: f"{m.group(1)};\n\n{m.group(2)}", text)
+
+# Ensure data classes implementing shared interfaces mark interface properties with override
+class_pattern = re.compile(
+    r"public data class [^(]+\((?P<body>.*?)\)\s*:\s*(?P<interfaces>[^\{]+)\{",
+    re.S,
+)
+
+product_props = {
+    "currency",
+    "debugDescription",
+    "description",
+    "displayName",
+    "displayPrice",
+    "id",
+    "platform",
+    "price",
+    "title",
+    "type",
+}
+
+purchase_props = {
+    "id",
+    "ids",
+    "isAutoRenewing",
+    "platform",
+    "productId",
+    "purchaseState",
+    "purchaseToken",
+    "quantity",
+    "transactionDate",
+}
+
+def needs_product_common(interfaces):
+    return any(name in interfaces for name in ("ProductCommon", "Product", "ProductSubscription"))
+
+
+def needs_purchase_common(interfaces):
+    return any(name in interfaces for name in ("PurchaseCommon", "Purchase"))
+
+
+def patch_class(match):
+    body = match.group("body")
+    raw_interfaces = match.group("interfaces")
+    interfaces = {token.strip() for token in raw_interfaces.replace("\n", " ").split(",")}
+
+    override_targets = set()
+    if needs_product_common(interfaces):
+        override_targets.update(product_props)
+    if needs_purchase_common(interfaces):
+        override_targets.update(purchase_props)
+
+    if not override_targets:
+        return match.group(0)
+
+    prop_pattern = re.compile(r"(^\s*)(val|var)\s+(\w+)(.*)$", re.M)
+
+    def replace_prop(prop_match):
+        indent, keyword, name, rest = prop_match.groups()
+        if name not in override_targets:
+            return prop_match.group(0)
+        # Avoid double prefixing if the generator ever adds override in the future
+        if keyword.startswith("override"):
+            return prop_match.group(0)
+        return f"{indent}override {keyword} {name}{rest}"
+
+    patched_body = prop_pattern.sub(replace_prop, body)
+    return match.group(0).replace(body, patched_body)
+
+
+text = class_pattern.sub(patch_class, text)
+target.write_text(text)
+PY
+
+printf 'Types.kt updated at %s\n' "${TARGET_FILE}"


### PR DESCRIPTION
Ensure CI fails when regenerating Types.kt would change the tree.\n\nKeeps the generator script idempotent so reruns stay no-op.